### PR TITLE
Initial implementation of the vmm-epoll crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
-name = "crate-template"
+name = "vmm-epoll"
 version = "0.1.0"
-authors = [TODO]
+authors = ["Liu Jiang <gerry@linux.alibaba.com>"]
+repository = "https://github.com/rust-vmm/vmm-epoll"
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
+epoll = ">=4.0.1"
+libc = ">=0.2.39"
+
+[dev-dependencies]
+vmm-sys-util = ">=0.3"

--- a/LICENSE-BSD
+++ b/LICENSE-BSD
@@ -1,0 +1,27 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.5,
+  "coverage_score": 90.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90,
+  "coverage_score": 76.5,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,168 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD file.
+
 #![deny(missing_docs)]
-//! Dummy crate needs high-level documentation.
-/// Dummy public function needs documentation.
-pub fn it_works() {
-    assert!(true);
+
+//! Traits to manage and poll IO event notifications for registered file decriptors by using epoll.
+//!
+//! The epoll API performs a similar task to poll(2): monitoring multiple file descriptors to see
+//! if I/O is possible on any of them. For a typical usage mode, multiple file descriptors are
+//! registered on a epoll fd, and a working thread polls and invokes event handler for IO event
+//! notifications from the epoll fd.
+//!
+//! Several traits are defined to support the above usage case:
+//! - EpollEventMgr: manages a epoll fd and a pool of event slots. One file descriptor/event handler
+//! could be registered onto each slot.
+//! - EpollSlotAllocator: allocates slots from the epoll event manager.
+//! - EpollSlotGroup: a group of slots allocated from the epoll event manager.
+
+use std::fmt;
+use std::fs::File;
+use std::os::unix::io::RawFd;
+
+/// Errors for epoll event manager.
+#[derive(Debug)]
+pub enum Error {
+    /// Invalid parameters.
+    InvalidParameter,
+    /// Operation not supported.
+    OperationNotSupported,
+    /// Slot is out of range.
+    SlotOutOfRange(EpollSlot),
+    /// Too many event slots.
+    TooManySlots(usize),
+    /// Event handler not ready.
+    HandlerNotReady,
+    /// Failure in epoll_ctl().
+    EpollCtl(std::io::Error),
+    /// Failure in epoll_wait().
+    EpollWait(std::io::Error),
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidParameter => write!(f, "invalid parameters"),
+            Error::OperationNotSupported => write!(f, "operation not supported"),
+            Error::SlotOutOfRange(slot) => write!(f, "slot {} is out of range", slot),
+            Error::TooManySlots(c) => write!(f, "too many slots {}, max {}", c, MAX_EPOLL_SLOTS),
+            Error::HandlerNotReady => write!(f, "event handler not ready"),
+            Error::EpollCtl(e) => write!(f, "failure in epoll_ctl(): {}", e),
+            Error::EpollWait(e) => write!(f, "failure in epoll_wait(): {}", e),
+        }
+    }
+}
+
+/// Result for epoll event management operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Maximum number of slots allowed for an allocation.
+pub const MAX_EPOLL_SLOTS: usize = 256;
+
+/// Epoll slot to associate a file descriptor with a registered `EpollHandler` handler.
+pub type EpollSlot = u64;
+
+/// The payload is used to handle events where the internal state of the VirtIO device
+/// needs to be changed.
+pub enum EpollHandlerPayload {
+    /// DrivePayload(disk_image)
+    DrivePayload(File),
+    /// Events that do not need a payload.
+    Empty,
+}
+
+/// Trait to handle epoll events for registered file descriptors.
+pub trait EpollHandler: Send {
+    /// Handle io events associated with the slot.
+    fn handle_event(
+        &mut self,
+        slot: EpollSlot,
+        event_flags: u32,
+        payload: EpollHandlerPayload,
+    ) -> Result<()>;
+}
+
+/// Trait to manage an epoll fd and a pool of event slots.
+trait EpollEventMgr {
+    /// Type of event slot allocator.
+    type A: EpollSlotAllocator;
+
+    /// Get an epoll slot allocator.
+    ///
+    /// # Arguments
+    /// * num_slots - number of event slots to allocate
+    /// * handler - event handler to associated with the allocated event slots
+    fn get_allocator(
+        &mut self,
+        num_slots: Option<usize>,
+        handler: Option<Box<EpollHandler>>,
+    ) -> Result<Self::A>;
+
+    /// Poll events from the epoll fd and invoke registered event handlers.
+    ///
+    /// # Arguments
+    /// * max_events - maximum number of events to handle
+    /// * timeout - minimum number of milliseconds that epoll_wait() will block
+    ///
+    /// Returns a (num_handled_events, num_unknown_events) tuple on success.
+    fn handle_events(&mut self, max_events: usize, timeout: i32) -> Result<(usize, usize)>;
+
+    /// Generate a fake epoll event and invoke the registered event handler.
+    fn inject_event(
+        &mut self,
+        slot: EpollSlot,
+        event_flags: u32,
+        payload: EpollHandlerPayload,
+    ) -> Result<()>;
+}
+
+/// Trait to allocate/free epoll event slots.
+pub trait EpollSlotAllocator {
+    /// Type of allocated event group object.
+    type G: EpollSlotGroup;
+
+    /// Allocate a group of event slots and associated them with `handler`.
+    ///
+    /// A file may be registered onto each allocated event slot, and IO event notifications
+    /// for those file descriptors will be handled by invoking `handler`.
+    fn allocate(&mut self, num_slots: usize, handler: Box<EpollHandler>) -> Result<Self::G>;
+
+    /// Free the allocated slots.
+    fn free(&mut self, group: &mut Self::G) -> Result<()>;
+}
+
+/// A group of event slots allocated from the epoll event manager.
+///
+/// A file descriptor may be associated for each allocated slot to poll specified epoll events.
+#[allow(clippy::len_without_is_empty)]
+pub trait EpollSlotGroup {
+    /// Get number of epoll slots allocated.
+    fn len(&self) -> usize;
+
+    /// Register the target file descriptor `fd` to be polled by the epoll manager.
+    ///
+    /// # Arguments
+    /// * `fd` - File descriptor to be monitored.
+    /// * `slot` -  an allocated epoll slot to be associated with `fd`.
+    /// * `events` - Epoll events to monitor.
+    fn register(&self, fd: RawFd, slot: EpollSlot, events: epoll::Events) -> Result<()>;
+
+    /// Deregister the target file descriptor `fd` from monitoring.
+    ///
+    /// # Arguments
+    /// * `fd` - File descriptor has been registered.
+    /// * `slot` -  an allocated epoll slot associated with `fd`.
+    /// * `events` - Monitored epoll events.
+    fn deregister(&self, fd: RawFd, slot: EpollSlot, events: epoll::Events) -> Result<()>;
+}
+
+mod vector_single_thread;
+pub use vector_single_thread::{
+    EpollEventMgrVector, EpollSlotAllocatorVector, EpollSlotGroupVector,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,4 +290,25 @@ mod tests {
         assert_eq!(token.get_slot(), 2);
         assert_eq!(token.get_user_data(), 3);
     }
+
+    #[test]
+    fn test_error() {
+        assert_eq!(format!("{}", Error::InvalidParameter), "invalid parameters");
+        assert_eq!(
+            format!("{}", Error::OperationNotSupported),
+            "operation not supported"
+        );
+        assert_eq!(
+            format!("{}", Error::SlotOutOfRange(1)),
+            "slot 1 is out of range"
+        );
+        assert_eq!(
+            format!("{}", Error::TooManySlots(MAX_EPOLL_SLOTS + 1)),
+            "too many slots 257, max 256"
+        );
+        assert_eq!(
+            format!("{}", Error::HandlerNotReady),
+            "event handler not ready"
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,24 +9,26 @@
 
 #![deny(missing_docs)]
 
-//! Traits to manage and poll IO event notifications for registered file decriptors by using epoll.
+//! Traits and Structs to manage and poll IO events by using epoll.
 //!
 //! The epoll API performs a similar task to poll(2): monitoring multiple file descriptors to see
 //! if I/O is possible on any of them. For a typical usage mode, multiple file descriptors are
 //! registered on a epoll fd, and a working thread polls and invokes event handler for IO event
 //! notifications from the epoll fd.
 //!
-//! Several traits are defined to support the above usage case:
-//! - EpollEventMgr: manages a epoll fd and a pool of event slots. One file descriptor/event handler
-//! could be registered onto each slot.
-//! - EpollSlotAllocator: allocates slots from the epoll event manager.
-//! - EpollSlotGroup: a group of slots allocated from the epoll event manager.
+//! This crate provides IO event management services to its clients by using epoll on Linux.
+//! An EpollEventMgrT object manages a epoll fd and a pool of slots. A client may allocate a
+//! group of slots from the epoll event manager, and associate an EpollHandler object to those
+//! allocated slots. A pair of (fd, epoll_events) may be registered on to each allocated slot.
+//! All IO events from the registered fd will be handled by the associated EpollHandler object.
+
+extern crate epoll;
 
 use std::fmt;
 use std::fs::File;
 use std::os::unix::io::RawFd;
 
-/// Errors for epoll event manager.
+/// Errors for epoll event management operations.
 #[derive(Debug)]
 pub enum Error {
     /// Invalid parameters.
@@ -36,13 +38,15 @@ pub enum Error {
     /// Slot is out of range.
     SlotOutOfRange(EpollSlot),
     /// Too many event slots.
-    TooManySlots(usize),
+    TooManySlots(EpollSlot),
     /// Event handler not ready.
     HandlerNotReady,
     /// Failure in epoll_ctl().
     EpollCtl(std::io::Error),
     /// Failure in epoll_wait().
     EpollWait(std::io::Error),
+    /// Generic IO errors
+    IOError(std::io::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -53,56 +57,122 @@ impl std::fmt::Display for Error {
             Error::SlotOutOfRange(slot) => write!(f, "slot {} is out of range", slot),
             Error::TooManySlots(c) => write!(f, "too many slots {}, max {}", c, MAX_EPOLL_SLOTS),
             Error::HandlerNotReady => write!(f, "event handler not ready"),
-            Error::EpollCtl(e) => write!(f, "failure in epoll_ctl(): {}", e),
-            Error::EpollWait(e) => write!(f, "failure in epoll_wait(): {}", e),
+            Error::EpollCtl(e) => write!(f, "epoll_ctl(): {}", e),
+            Error::EpollWait(e) => write!(f, "epoll_wait(): {}", e),
+            Error::IOError(e) => write!(f, "{}", e),
         }
     }
 }
 
-/// Result for epoll event management operations.
-pub type Result<T> = std::result::Result<T, Error>;
+/// Maximum number of slots allowed in an allocated group.
+pub const MAX_EPOLL_SLOTS: EpollSlot = 256;
 
-/// Maximum number of slots allowed for an allocation.
-pub const MAX_EPOLL_SLOTS: usize = 256;
+/// Slot identifiers to associate file descriptors with registered `EpollHandler` handlers.
+pub type EpollSlot = u32;
 
-/// Epoll slot to associate a file descriptor with a registered `EpollHandler` handler.
-pub type EpollSlot = u64;
+/// User data associated with an epoll slot.
+pub type EpollUserData = u32;
 
-/// The payload is used to handle events where the internal state of the VirtIO device
-/// needs to be changed.
+/// Reexported epoll::Events to avoid importing epoll crate to every user.
+pub type EpollEvents = epoll::Events;
+
+/// The payload is used to handle events where the internal state of the client needs to be changed.
 pub enum EpollHandlerPayload {
-    /// DrivePayload(disk_image)
+    /// DrivePayload(disk_image), a special case inherited from the firecracker project.
     DrivePayload(File),
     /// Events that do not need a payload.
     Empty,
 }
 
+/// Data attached to the epoll_event.data field when registering an epoll event.
+/// The lower 32-bit contains an EpollSlot, the upper 32-bit contains EpollUserData.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub struct EpollToken(u64);
+
+impl EpollToken {
+    /// Create a new EpollToken instance.
+    pub fn new(slot: EpollSlot, data: EpollUserData) -> Self {
+        EpollToken(u64::from(data) << 32 | u64::from(slot))
+    }
+
+    /// Create a new EpollToken instance without user data.
+    pub fn from_slot(slot: EpollSlot) -> Self {
+        Self::new(slot, 0)
+    }
+
+    /// Set epoll slot into the token.
+    #[inline]
+    pub fn set_slot(&mut self, slot: EpollSlot) {
+        self.0 &= !0xFFFF_FFFFu64;
+        self.0 |= u64::from(slot);
+    }
+
+    /// Get epoll slot from the token.
+    #[inline]
+    pub fn get_slot(self) -> u32 {
+        self.0 as u32
+    }
+
+    /// Set user data into the token.
+    #[inline]
+    pub fn set_user_data(&mut self, data: EpollUserData) {
+        self.0 &= 0xFFFF_FFFFu64;
+        self.0 |= u64::from(data) << 32;
+    }
+
+    /// Get user data from the token.
+    #[inline]
+    pub fn get_user_data(self) -> u32 {
+        (self.0 >> 32) as u32
+    }
+}
+
 /// Trait to handle epoll events for registered file descriptors.
 pub trait EpollHandler: Send {
-    /// Handle io events associated with the slot.
+    /// Type of returned Error.
+    ///
+    /// This associated type is for errors in the client domain instead of errors from the epoll
+    /// manager itself.
+    type E: From<Error> + Send + Sync;
+
+    /// Handle IO events for the registered file descriptor.
     fn handle_event(
         &mut self,
         slot: EpollSlot,
-        event_flags: u32,
+        event: EpollEvents,
+        data: EpollUserData,
         payload: EpollHandlerPayload,
-    ) -> Result<()>;
+    ) -> Result<(), Self::E>;
+
+    /// Set or unset the epoll slot group object associated with the handler.
+    ///
+    /// It will be called during EpollSlotAllocatorT::allocate() with a valid group object,
+    /// EpollSlotAllocatorT::allocate() fails if set_group() returns errors.
+    /// It will also be called during EpollSlotAllocatorT::free() with null group object
+    /// to drop the group object provided during allocated(), and set_group() should never fails
+    /// in this case.
+    fn set_group(
+        &mut self,
+        _group: Option<Box<EpollSlotGroupT>>,
+    ) -> std::result::Result<(), Self::E> {
+        Ok(())
+    }
 }
 
 /// Trait to manage an epoll fd and a pool of event slots.
-trait EpollEventMgr {
+pub trait EpollEventMgrT {
     /// Type of event slot allocator.
-    type A: EpollSlotAllocator;
+    type A: EpollSlotAllocatorT<E = Self::E>;
+    /// Type of returned Error.
+    type E: std::convert::From<Error> + Send + Sync;
 
     /// Get an epoll slot allocator.
     ///
     /// # Arguments
-    /// * num_slots - number of event slots to allocate
-    /// * handler - event handler to associated with the allocated event slots
-    fn get_allocator(
-        &mut self,
-        num_slots: Option<usize>,
-        handler: Option<Box<EpollHandler>>,
-    ) -> Result<Self::A>;
+    /// * num_slots - optional number of event slots to allocate
+    ///
+    /// When `num_slots` contains a valid number, `num_slots` event slots will be pre-allocated.
+    fn get_allocator(&mut self, num_slots: Option<EpollSlot>) -> Result<Self::A, Error>;
 
     /// Poll events from the epoll fd and invoke registered event handlers.
     ///
@@ -111,37 +181,53 @@ trait EpollEventMgr {
     /// * timeout - minimum number of milliseconds that epoll_wait() will block
     ///
     /// Returns a (num_handled_events, num_unknown_events) tuple on success.
-    fn handle_events(&mut self, max_events: usize, timeout: i32) -> Result<(usize, usize)>;
+    fn handle_events(&mut self, max_events: usize, timeout: i32)
+        -> Result<(usize, usize), Self::E>;
 
     /// Generate a fake epoll event and invoke the registered event handler.
     fn inject_event(
         &mut self,
         slot: EpollSlot,
-        event_flags: u32,
+        events: EpollEvents,
+        data: EpollUserData,
         payload: EpollHandlerPayload,
-    ) -> Result<()>;
+    ) -> Result<(), Self::E>;
 }
 
 /// Trait to allocate/free epoll event slots.
-pub trait EpollSlotAllocator {
+pub trait EpollSlotAllocatorT: Send {
     /// Type of allocated event group object.
-    type G: EpollSlotGroup;
+    type G: EpollSlotGroupT;
+    /// Type of returned Error.
+    type E: From<Error> + Send + Sync;
 
-    /// Allocate a group of event slots and associated them with `handler`.
+    /// Allocate a group of continuous event slots and associated them with `handler`.
     ///
     /// A file may be registered onto each allocated event slot, and IO event notifications
     /// for those file descriptors will be handled by invoking `handler`.
-    fn allocate(&mut self, num_slots: usize, handler: Box<EpollHandler>) -> Result<Self::G>;
+    fn allocate(
+        &mut self,
+        num_slots: EpollSlot,
+        handler: Box<EpollHandler<E = Self::E>>,
+    ) -> Result<Self::G, Self::E>;
 
     /// Free the allocated slots.
-    fn free(&mut self, group: &mut Self::G) -> Result<()>;
+    fn free(&mut self, group: Self::G) -> Result<Box<EpollHandler<E = Self::E>>, Self::E>;
+
+    /// Get the base of the pre-allocated slots.
+    fn base(&self) -> Option<EpollSlot> {
+        None
+    }
 }
 
-/// A group of event slots allocated from the epoll event manager.
+/// A group of epoll slots allocated from the epoll event manager.
 ///
-/// A file descriptor may be associated for each allocated slot to poll specified epoll events.
+/// A file descriptor may be associated with each allocated slot to poll specified IO events.
 #[allow(clippy::len_without_is_empty)]
-pub trait EpollSlotGroup {
+pub trait EpollSlotGroupT: Send + Sync {
+    /// Get the base of allocated slots.
+    fn base(&self) -> EpollSlot;
+
     /// Get number of epoll slots allocated.
     fn len(&self) -> usize;
 
@@ -149,20 +235,59 @@ pub trait EpollSlotGroup {
     ///
     /// # Arguments
     /// * `fd` - File descriptor to be monitored.
-    /// * `slot` -  an allocated epoll slot to be associated with `fd`.
+    /// * `slot` - index into the allocated slot group.
+    /// * `data` - user data associated with the slot.
     /// * `events` - Epoll events to monitor.
-    fn register(&self, fd: RawFd, slot: EpollSlot, events: epoll::Events) -> Result<()>;
+    fn register(
+        &self,
+        fd: RawFd,
+        slot: EpollSlot,
+        data: EpollUserData,
+        events: epoll::Events,
+    ) -> Result<(), Error>;
 
     /// Deregister the target file descriptor `fd` from monitoring.
     ///
     /// # Arguments
     /// * `fd` - File descriptor has been registered.
-    /// * `slot` -  an allocated epoll slot associated with `fd`.
+    /// * `slot` - index into the allocated slot group.
+    /// * `data` - user data associated with the slot.
     /// * `events` - Monitored epoll events.
-    fn deregister(&self, fd: RawFd, slot: EpollSlot, events: epoll::Events) -> Result<()>;
+    fn deregister(
+        &self,
+        fd: RawFd,
+        slot: EpollSlot,
+        data: EpollUserData,
+        events: epoll::Events,
+    ) -> Result<(), Error>;
 }
 
+/// A simple vector based epoll manager which could only be accessed from a single working thread.
 mod vector_single_thread;
 pub use vector_single_thread::{
-    EpollEventMgrVector, EpollSlotAllocatorVector, EpollSlotGroupVector,
+    EpollEventMgrVector as EpollEventMgr, EpollSlotAllocatorVector as EpollSlotAllocator,
+    EpollSlotGroupVector as EpollSlotGroup,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_token() {
+        let mut token = EpollToken::new(1, 1);
+        assert_eq!(token, EpollToken(0x1_0000_0001));
+        assert_eq!(token.get_slot(), 1);
+        assert_eq!(token.get_user_data(), 1);
+
+        token.set_slot(2);
+        assert_eq!(token, EpollToken(0x1_0000_0002));
+        assert_eq!(token.get_slot(), 2);
+        assert_eq!(token.get_user_data(), 1);
+
+        token.set_user_data(3);
+        assert_eq!(token, EpollToken(0x3_0000_0002));
+        assert_eq!(token.get_slot(), 2);
+        assert_eq!(token.get_user_data(), 3);
+    }
+}

--- a/src/vector_single_thread.rs
+++ b/src/vector_single_thread.rs
@@ -1,0 +1,409 @@
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD file.
+
+//! A simple vector based epoll event manager which only supports static slot allocation.
+//!
+//! For VMMs which don't support device hot-addition/removal, a simple epoll event manager which
+//! only supports static allocation should be good enough. On startup a group of epoll slots are
+//! allocated for each consumer/device, and those allocated slots won't be freed.
+//! For simplicity and performance, vector is used to store registered handlers and there's no
+//! synchronization mechanism adopted, so the statically allocated slot group could be
+//! accessed/used by a single thread.
+
+use std::os::unix::io::RawFd;
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+use crate::{
+    EpollEventMgr, EpollHandler, EpollHandlerPayload, EpollSlot, EpollSlotAllocator,
+    EpollSlotGroup, Error, Result, MAX_EPOLL_SLOTS,
+};
+
+struct MaybeHandler {
+    handler: Option<Box<EpollHandler>>,
+    receiver: Receiver<Box<EpollHandler>>,
+}
+
+impl MaybeHandler {
+    fn new(handler: Option<Box<EpollHandler>>, receiver: Receiver<Box<EpollHandler>>) -> Self {
+        MaybeHandler { handler, receiver }
+    }
+}
+
+/// A simple vector based event manager which only supports static slot allocation.
+pub struct EpollEventMgrVector {
+    epoll_raw_fd: RawFd,
+    event_handlers: Vec<MaybeHandler>,
+    dispatch_table: Vec<(usize, EpollSlot)>,
+}
+
+impl EpollEventMgrVector {
+    /// Create a new EpollEventMgrVector object.
+    ///
+    /// If `cloexec` is true, FD_CLOEXEC will be set on the underline epoll fd.
+    pub fn new(cloexec: bool, capacity: usize) -> Self {
+        // Just assume always success to create epoll fd.
+        let epoll_raw_fd = epoll::create(cloexec).expect("failed to create epoll fd");
+
+        EpollEventMgrVector {
+            epoll_raw_fd,
+            event_handlers: Vec::with_capacity(capacity),
+            dispatch_table: Vec::with_capacity(capacity),
+        }
+    }
+
+    fn get_handler(&mut self, event_idx: usize) -> Result<&mut EpollHandler> {
+        let maybe = &mut self.event_handlers[event_idx];
+        match maybe.handler {
+            Some(ref mut v) => Ok(v.as_mut()),
+            None => {
+                // This should only be called in response to an epoll trigger.
+                // Moreover, this branch of the match should only be active on the first call
+                // (the first epoll event for this device), therefore the channel is guaranteed
+                // to contain a message for the first epoll event since both epoll event
+                // registration and channel send() happen in the device activate() function.
+                let received = maybe
+                    .receiver
+                    .try_recv()
+                    .map_err(|_| Error::HandlerNotReady)?;
+                Ok(maybe.handler.get_or_insert(received).as_mut())
+            }
+        }
+    }
+
+    fn poll_events(&mut self, events: &mut [epoll::Event], timeout: i32) -> Result<(usize, usize)> {
+        let mut handled = 0;
+        let mut unknown = 0;
+
+        let num_events =
+            epoll::wait(self.epoll_raw_fd, timeout, events).map_err(Error::EpollWait)?;
+        for event in events.iter().take(num_events) {
+            let dispatch_idx = event.data as usize;
+            if dispatch_idx >= self.dispatch_table.len() {
+                unknown += 1;
+            } else {
+                let (handler_idx, slot) = self.dispatch_table[dispatch_idx];
+                // It's serious issue if fails to get handler, shouldn't happen.
+                let handler = self.get_handler(handler_idx)?;
+                // Handler shouldn't return error, there's no common way for the manager to recover from failure.
+                handler
+                    .handle_event(slot, event.events, EpollHandlerPayload::Empty)
+                    .expect("epoll event handler should not return error.");
+                handled += 1;
+            }
+        }
+
+        Ok((handled, unknown))
+    }
+}
+
+impl EpollEventMgr for EpollEventMgrVector {
+    type A = EpollSlotAllocatorVector;
+
+    fn get_allocator(
+        &mut self,
+        num_slots: Option<usize>,
+        handler: Option<Box<EpollHandler>>,
+    ) -> Result<Self::A> {
+        let count = match num_slots {
+            Some(val) => {
+                if val > MAX_EPOLL_SLOTS {
+                    return Err(Error::TooManySlots(val));
+                } else if val == 0 {
+                    return Err(Error::InvalidParameter);
+                }
+                val
+            }
+            None => {
+                return Err(Error::InvalidParameter);
+            }
+        };
+
+        let dispatch_base = self.dispatch_table.len() as u64;
+        let handler_idx = self.event_handlers.len();
+        let (sender, receiver) = channel();
+
+        for x in 0..count {
+            self.dispatch_table.push((handler_idx, x as EpollSlot));
+        }
+        self.event_handlers
+            .push(MaybeHandler::new(handler, receiver));
+
+        Ok(EpollSlotAllocatorVector::new(
+            dispatch_base,
+            count,
+            self.epoll_raw_fd,
+            sender,
+        ))
+    }
+
+    fn handle_events(&mut self, max_events: usize, timeout: i32) -> Result<(usize, usize)> {
+        if max_events == 0 {
+            return Err(Error::InvalidParameter);
+        }
+        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); max_events];
+        self.poll_events(&mut events, timeout)
+    }
+
+    fn inject_event(
+        &mut self,
+        slot: EpollSlot,
+        event_flags: u32,
+        payload: EpollHandlerPayload,
+    ) -> Result<()> {
+        if slot >= self.dispatch_table.len() as EpollSlot {
+            Err(Error::SlotOutOfRange(slot))
+        } else {
+            let (handler_idx, slot) = self.dispatch_table[slot as usize];
+            // It's serious issue if fails to get handler, shouldn't happen.
+            let handler = self.get_handler(handler_idx)?;
+            // Handler shouldn't return error, there's no common way for the manager to recover from failure.
+            handler
+                .handle_event(slot, event_flags, payload)
+                .expect("epoll event handler should not return error.");
+            Ok(())
+        }
+    }
+}
+
+impl Drop for EpollEventMgrVector {
+    fn drop(&mut self) {
+        let rc = unsafe { libc::close(self.epoll_raw_fd) };
+        if rc != 0 {
+            //error!("EpollEventMgrVector can't close event fd.");
+        }
+    }
+}
+
+/// Struct to statically allocate and manage epoll slots.
+///
+/// A group of epoll slots are statically allocated and will never be freed. So it can't support
+/// device hot-removal. For simplicity and performance, there's no synchronization mechanism adopted
+/// and the structure can only be accessed from a single thread.
+pub struct EpollSlotAllocatorVector {
+    first_slot: EpollSlot,
+    num_slots: usize,
+    epoll_raw_fd: RawFd,
+    sender: Sender<Box<EpollHandler>>,
+}
+
+impl EpollSlotAllocatorVector {
+    /// Create a new EpollSlotGroup object.
+    fn new(
+        first_slot: EpollSlot,
+        num_slots: usize,
+        epoll_raw_fd: RawFd,
+        sender: Sender<Box<EpollHandler>>,
+    ) -> Self {
+        EpollSlotAllocatorVector {
+            first_slot,
+            num_slots,
+            epoll_raw_fd,
+            sender,
+        }
+    }
+}
+
+impl EpollSlotAllocator for EpollSlotAllocatorVector {
+    type G = EpollSlotGroupVector;
+
+    fn allocate(&mut self, num_slots: usize, handler: Box<EpollHandler>) -> Result<Self::G> {
+        if num_slots != self.num_slots {
+            return Err(Error::SlotOutOfRange(num_slots as EpollSlot));
+        }
+        //channel should be open and working
+        self.sender
+            .send(handler)
+            .expect("Failed to send through the channel");
+        Ok(EpollSlotGroupVector {
+            first_slot: self.first_slot,
+            num_slots: self.num_slots,
+            epoll_raw_fd: self.epoll_raw_fd,
+        })
+    }
+
+    fn free(&mut self, _group: &mut Self::G) -> Result<()> {
+        Err(Error::OperationNotSupported)
+    }
+}
+
+/// Struct to maintain information about a group of allocated slots.
+pub struct EpollSlotGroupVector {
+    first_slot: EpollSlot,
+    num_slots: usize,
+    epoll_raw_fd: RawFd,
+}
+
+impl EpollSlotGroup for EpollSlotGroupVector {
+    fn len(&self) -> usize {
+        self.num_slots
+    }
+
+    fn register(&self, fd: RawFd, slot: EpollSlot, events: epoll::Events) -> Result<()> {
+        if slot >= self.num_slots as u64 || slot.checked_add(self.num_slots as u64).is_none() {
+            return Err(Error::SlotOutOfRange(slot));
+        }
+        epoll::ctl(
+            self.epoll_raw_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            fd,
+            epoll::Event::new(events, self.first_slot + slot),
+        )
+        .map_err(Error::EpollCtl)
+    }
+
+    fn deregister(&self, fd: RawFd, slot: EpollSlot, events: epoll::Events) -> Result<()> {
+        if slot >= self.num_slots as u64 || slot.checked_add(self.num_slots as u64).is_none() {
+            return Err(Error::SlotOutOfRange(slot));
+        }
+        epoll::ctl(
+            self.epoll_raw_fd,
+            epoll::ControlOptions::EPOLL_CTL_DEL,
+            fd,
+            epoll::Event::new(events, self.first_slot + slot),
+        )
+        .map_err(Error::EpollCtl)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate vmm_sys_util;
+
+    use super::*;
+
+    use std::os::unix::io::AsRawFd;
+    use std::thread;
+    use vmm_sys_util::eventfd::EventFd;
+
+    struct TestEvent {
+        evfd: EventFd,
+        count: u64,
+        write: bool,
+    }
+
+    impl TestEvent {
+        fn new(write: bool) -> Self {
+            TestEvent {
+                evfd: EventFd::new(0).unwrap(),
+                count: 0,
+                write,
+            }
+        }
+    }
+
+    impl EpollHandler for TestEvent {
+        fn handle_event(
+            &mut self,
+            _data: EpollSlot,
+            _event_flags: u32,
+            _payload: EpollHandlerPayload,
+        ) -> Result<()> {
+            self.count += 1;
+            if self.write {
+                self.evfd.write(1).unwrap();
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn epoll_get_allocator_test() {
+        let mut ep = EpollEventMgrVector::new(true, 2);
+
+        let err = ep.get_allocator(None, None);
+        match err {
+            Err(Error::InvalidParameter) => {}
+            _ => panic!("error expected"),
+        }
+
+        let err = ep.get_allocator(Some(0), None);
+        match err {
+            Err(Error::InvalidParameter) => {}
+            _ => panic!("error expected"),
+        }
+
+        let err = ep.get_allocator(Some(MAX_EPOLL_SLOTS + 1), None);
+        match err {
+            Err(Error::TooManySlots(count)) => {
+                assert_eq!(count, MAX_EPOLL_SLOTS + 1);
+            }
+            _ => panic!("error expected"),
+        }
+
+        let allocator = ep.get_allocator(Some(2), None).unwrap();
+        assert_eq!(ep.event_handlers.len(), 1);
+        assert_eq!(ep.dispatch_table.len(), 2);
+        assert_eq!(allocator.num_slots, 2);
+
+        let allocator = ep.get_allocator(Some(2), None).unwrap();
+        assert_eq!(ep.event_handlers.len(), 2);
+        assert_eq!(ep.dispatch_table.len(), 4);
+        assert_eq!(allocator.num_slots, 2);
+
+        let allocator = ep.get_allocator(Some(MAX_EPOLL_SLOTS), None).unwrap();
+        assert_eq!(ep.event_handlers.len(), 3);
+        assert_eq!(ep.dispatch_table.len(), 4 + MAX_EPOLL_SLOTS);
+        assert_eq!(allocator.num_slots, MAX_EPOLL_SLOTS);
+    }
+
+    #[test]
+    fn epoll_inject_event_test() {
+        let mut ep = EpollEventMgrVector::new(true, 1);
+
+        let err = ep.inject_event(0, 0, EpollHandlerPayload::Empty);
+        match err {
+            Err(Error::SlotOutOfRange(slot)) => {
+                assert_eq!(slot, 0);
+            }
+            _ => panic!("error expected"),
+        }
+
+        let handler = TestEvent::new(true);
+        let evfd = handler.evfd.try_clone().unwrap();
+        let _ = ep.get_allocator(Some(2), Some(Box::new(handler))).unwrap();
+        assert_eq!(ep.event_handlers.len(), 1);
+        assert_eq!(ep.dispatch_table.len(), 2);
+
+        assert!(ep.inject_event(1, 0, EpollHandlerPayload::Empty).is_ok());
+        let val = evfd.read().unwrap();
+        assert_eq!(val, 1);
+
+        assert!(ep.inject_event(1, 0, EpollHandlerPayload::Empty).is_ok());
+        assert!(ep.inject_event(2, 0, EpollHandlerPayload::Empty).is_err());
+        assert!(ep.inject_event(1, 0, EpollHandlerPayload::Empty).is_ok());
+        let val = evfd.read().unwrap();
+        assert_eq!(val, 2);
+    }
+
+    #[test]
+    fn epoll_handle_events_test() {
+        let mut ep = EpollEventMgrVector::new(true, 1);
+
+        let err = ep.handle_events(0, 1).unwrap_err();
+        match err {
+            Error::InvalidParameter => {}
+            _ => panic!("error expected"),
+        }
+
+        assert_eq!(ep.handle_events(1, 1).unwrap(), (0, 0));
+        assert_eq!(ep.handle_events(1, 0).unwrap(), (0, 0));
+
+        let handler = TestEvent::new(false);
+        let evfd = handler.evfd.try_clone().unwrap();
+        let mut allocator = ep.get_allocator(Some(2), None).unwrap();
+        thread::spawn(move || {
+            let fd = handler.evfd.as_raw_fd();
+            let group = allocator.allocate(2, Box::new(handler)).unwrap();
+            assert_eq!(group.len(), 2);
+            group.register(fd, 1, epoll::Events::EPOLLIN).unwrap();
+            evfd.write(1).unwrap();
+        });
+        ep.handle_events(10, -1).unwrap();
+    }
+}


### PR DESCRIPTION
The initial implementation is derived from firecracker project, with several Traits to abstract the interfaces.
Later we will add an multi-thread safe implementation to support device hotplug.