### PR TITLE
Initial Implementation - v3

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+# This workaround is needed because the linker is unable to find __addtf3,
+# __multf3 and __subtf3.
+# Related issue: https://github.com/rust-lang/compiler-builtins/issues/201
+[target.aarch64-unknown-linux-musl]
+rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
-name = "crate-template"
+name = "event-manager"
 version = "0.1.0"
-authors = [TODO]
+authors = ["Firecracker Team <firecracker-maintainers@amazon.com>"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
+vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+libc = ">=0.2.39"
+
+[features]
+remote_endpoint = []

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90,
+  "coverage_score": 87.3,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 90.4,
+  "exclude_path": "",
+  "crate_features": ""
+}

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::result;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::Arc;
+
+use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+
+use super::{Error, EventSubscriber, Result, SubscriberOps};
+
+// A manager remote endpoint allows user to interact with the `EventManger` (as a `SubscriberOps`
+// trait object) from a different thread of execution. This is particularly useful when the
+// `EventManager` owns (via `EventManager::add_subscriber`) a subscriber object the user wishes
+// to work with (via `EventManager::subscriber_mut`), but the `EventManager` being on a different
+// thread requires synchronized handles.
+
+// Until more sophisticated methods are explored (for example making the `EventManager` offer
+// interior mutability using something like an RCU mechanism), the current proposal relies on
+// passing boxed closures to the manager and getting back a boxed result. The manager is notified
+// about incoming invocation requests via an `EventFd` which is added to the epoll event set.
+// The signature of the closures as they are received is the `FnOnceBox` type alias defined
+// below. The actual return type is opaque to the manager, but known by the initiator. The manager
+// runs each closure to completion, and then returns the boxed result using a sender object that
+// is part of the initial message that also included the closure.
+
+// The return type of the closure received by the manager is erased (by placing it into a
+// `Box<dyn Any + Send>` in order to have a single concrete type definition for the messages that
+// contain closures to be executed (the `FnMsg` defined below). The actual return type is
+// recovered by the initiator of the remote call (more details in the implementation of
+// `RemoteEndpoint::call_blocking` below). The `Send` bound is required to send back the boxed
+// result over the return channel.
+type ErasedResult = Box<dyn Any + Send>;
+
+// Type alias for the boxed closures received by the manager. The `Send` bound at the end applies
+// to the type of the closure, and is required to send the box over the channel.
+type FnOnceBox<S> = Box<dyn FnOnce(&mut dyn SubscriberOps<Subscriber = S>) -> ErasedResult + Send>;
+
+// The type of the messages received by the manager over its receive mpsc channel.
+pub(crate) struct FnMsg<S> {
+    // The closure to execute.
+    pub(crate) fnbox: FnOnceBox<S>,
+    // The sending endpoint of the channel used by the remote called to wait for the result.
+    pub(crate) sender: Sender<ErasedResult>,
+}
+
+// Used by the `EventManager` to keep state associated with the channel.
+pub(crate) struct EventManagerChannel<S> {
+    // A clone of this is given to every `RemoteEndpoint` and used to signal the presence of
+    // an new message on the channel.
+    pub(crate) event_fd: Arc<EventFd>,
+    // A clone of this sender is given to every `RemoteEndpoint` and used to send `FnMsg` objects
+    // to the `EventManager` over the channel.
+    pub(crate) sender: Sender<FnMsg<S>>,
+    // The receiving half of the channel, used to receive incoming `FnMsg` objects.
+    pub(crate) receiver: Receiver<FnMsg<S>>,
+}
+
+impl<S> EventManagerChannel<S> {
+    pub(crate) fn new() -> Result<Self> {
+        let (sender, receiver) = channel();
+        Ok(EventManagerChannel {
+            event_fd: Arc::new(EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?),
+            sender,
+            receiver,
+        })
+    }
+
+    pub(crate) fn fd(&self) -> RawFd {
+        self.event_fd.as_raw_fd()
+    }
+
+    pub(crate) fn remote_endpoint(&self) -> RemoteEndpoint<S> {
+        RemoteEndpoint {
+            msg_sender: self.sender.clone(),
+            event_fd: self.event_fd.clone(),
+        }
+    }
+}
+
+/// Enables interactions with an `EventManager` that runs on a different thread of execution.
+#[derive(Clone)]
+pub struct RemoteEndpoint<S> {
+    // A sender associated with `EventManager` channel requests are sent over.
+    msg_sender: Sender<FnMsg<S>>,
+    // Used to notify the `EventManager` about the arrival of a new request.
+    event_fd: Arc<EventFd>,
+}
+
+impl<S: EventSubscriber> RemoteEndpoint<S> {
+    // Send a message to the remote EventManger and raise a notification.
+    fn send(&self, msg: FnMsg<S>) -> Result<()> {
+        self.msg_sender.send(msg).map_err(|_| Error::ChannelSend)?;
+        self.event_fd.write(1).map_err(Error::EventFd)?;
+        Ok(())
+    }
+
+    /// Call the specified closure on the associated remote `EventManager` (provided as a
+    /// `SubscriberOps` trait object), and return the result. This method blocks until the result
+    /// is received, and calling it from the same thread where the event loop runs leads to
+    /// a deadlock.
+    pub fn call_blocking<F, O, E>(&self, f: F) -> result::Result<O, E>
+    where
+        F: FnOnce(&mut dyn SubscriberOps<Subscriber = S>) -> result::Result<O, E> + Send + 'static,
+        O: Send + 'static,
+        E: From<Error> + Send + 'static,
+    {
+        // Create a temporary channel used to get back the result. We keep the receiving end,
+        // and put the sending end into the message we pass to the remote `EventManager`.
+        let (sender, receiver) = channel();
+
+        // We erase the return type of `f` by moving and calling it inside another closure which
+        // hides the result as an `ErasedResult`. This allows using the same channel send closures
+        // with different signatures (and thus different types) to the remote `EventManager`.
+        let fnbox = Box::new(
+            move |ops: &mut dyn SubscriberOps<Subscriber = S>| -> ErasedResult { Box::new(f(ops)) },
+        );
+
+        // Send the message requesting the closure invocation.
+        self.send(FnMsg { fnbox, sender })?;
+
+        // Block until a response is received. We can use unwrap because the downcast cannot fail,
+        // since the signature of F (more specifically, the return value) constrains the concrete
+        // type that's in the box.
+        let result_box = receiver
+            .recv()
+            .map_err(|_| Error::ChannelRecv)?
+            .downcast()
+            .unwrap();
+
+        // Turns out the dereference operator has a special behaviour for boxed objects; if we
+        // own a `b: Box<T>` and call `*b`, the box goes away and we get the `T` inside.
+        *result_box
+    }
+}

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -1,0 +1,60 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::os::unix::io::RawFd;
+
+use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent};
+
+use super::{Error, EventOps, Result, SubscriberId};
+
+// Internal use structure that keeps the epoll related state of an EventManager.
+pub(crate) struct EpollWrapper {
+    // The epoll wrapper.
+    pub(crate) epoll: Epoll,
+    // Records the id of the subscriber associated with the given RawFd. The event event_manager
+    // does not currently support more than one subscriber being associated with an fd.
+    pub(crate) fd_dispatch: HashMap<RawFd, SubscriberId>,
+    // Records the set of fds that are associated with the subscriber that has the given id.
+    // This is used to keep track of all fds associated with a subscriber.
+    pub(crate) subscriber_watch_list: HashMap<SubscriberId, Vec<RawFd>>,
+}
+
+impl EpollWrapper {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(EpollWrapper {
+            epoll: Epoll::new().map_err(Error::Epoll)?,
+            fd_dispatch: HashMap::new(),
+            subscriber_watch_list: HashMap::new(),
+        })
+    }
+
+    // Remove the fds associated with the provided subscriber id from the epoll set and the
+    // other structures. The subscriber id must be valid.
+    pub(crate) fn remove(&mut self, subscriber_id: SubscriberId) {
+        let fds = self
+            .subscriber_watch_list
+            .remove(&subscriber_id)
+            .unwrap_or_else(Vec::new);
+        for fd in fds {
+            // We ignore the result of the operation since there's nothing we can't do, and its
+            // not a significant error condition at this point.
+            let _ = self
+                .epoll
+                .ctl(ControlOperation::Delete, fd, EpollEvent::default());
+            self.fd_dispatch.remove(&fd);
+        }
+    }
+
+    // Gets the id of the subscriber associated with the provided fd (if such an association
+    // exists).
+    pub(crate) fn subscriber_id(&self, fd: RawFd) -> Option<SubscriberId> {
+        self.fd_dispatch.get(&fd).copied()
+    }
+
+    // Creates and returns a ControlOps object for the subscriber associated with the provided
+    // id. The subscriber id must be valid.
+    pub(crate) fn ops_unchecked(&mut self, subscriber_id: SubscriberId) -> EventOps {
+        EventOps::new(self, subscriber_id)
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,212 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use super::{Error, Result, SubscriberId};
+use crate::epoll::EpollWrapper;
+use vmm_sys_util::epoll::{ControlOperation, EpollEvent, EventSet};
+
+/// Wrapper over an `epoll::EpollEvent` object.
+///
+/// When working directly with epoll related methods, the user associates an `u64` wide
+/// epoll_data_t object with every event. We want to use fds as identifiers, but at the same time
+/// keep the ability to associate opaque data with an event. An `Events` object always contains an
+/// fd and an `u32` data member that can be supplied by the user. When registering events with the
+/// inner epoll event set, the fd and data members of `Events` as used together to generate the
+/// underlying `u64` member of the epoll_data union.
+#[derive(Clone, Copy, Debug)]
+pub struct Events {
+    inner: EpollEvent,
+}
+
+impl PartialEq for Events {
+    fn eq(&self, other: &Events) -> bool {
+        self.fd() == other.fd()
+            && self.data() == other.data()
+            && self.event_set() == other.event_set()
+    }
+}
+
+impl Events {
+    pub(crate) fn with_inner(inner: EpollEvent) -> Self {
+        Self { inner }
+    }
+
+    /// Create an empty event set associated with the supplied fd.
+    pub fn empty<T: AsRawFd>(source: &T) -> Self {
+        Self::empty_raw(source.as_raw_fd())
+    }
+
+    /// Create an empty event set associated with the supplied `RawFd` value.
+    pub fn empty_raw(fd: RawFd) -> Self {
+        Self::new_raw(fd, EventSet::empty())
+    }
+
+    /// Create an event set associated with the supplied fd and active events.
+    pub fn new<T: AsRawFd>(source: &T, events: EventSet) -> Self {
+        Self::new_raw(source.as_raw_fd(), events)
+    }
+
+    /// Create an event set associated with the supplied `RawFd` value and active events.
+    pub fn new_raw(source: RawFd, events: EventSet) -> Self {
+        Self::with_data_raw(source, 0, events)
+    }
+
+    /// Create an event set associated with the supplied fd, active events, and data.
+    pub fn with_data<T: AsRawFd>(source: &T, data: u32, events: EventSet) -> Self {
+        Self::with_data_raw(source.as_raw_fd(), data, events)
+    }
+
+    /// Create an event set associated with the supplied `RawFd` value, active events, and data.
+    pub fn with_data_raw(source: RawFd, data: u32, events: EventSet) -> Self {
+        let inner_data = ((data as u64) << 32) + (source as u64);
+        Events {
+            inner: EpollEvent::new(events, inner_data),
+        }
+    }
+
+    /// Return the inner fd value.
+    pub fn fd(&self) -> RawFd {
+        self.inner.data() as RawFd
+    }
+
+    /// Return the inner data value.
+    pub fn data(&self) -> u32 {
+        (self.inner.data() >> 32) as u32
+    }
+
+    /// Return the active event set.
+    pub fn event_set(&self) -> EventSet {
+        self.inner.event_set()
+    }
+
+    /// Return the inner `EpollEvent`.
+    pub fn epoll_event(&self) -> EpollEvent {
+        self.inner
+    }
+}
+
+/// This opaque object is associated with an `EventSubscriber`, and allows the addition,
+/// modification, and removal of file descriptor events within the inner epoll set of an
+/// `EventManager`.
+// Right now this is a concrete object, but going further it can be turned into a trait and
+// passed around as a trait object.
+pub struct EventOps<'a> {
+    // Mutable reference to the EpollContext of an EventManager.
+    epoll_wrapper: &'a mut EpollWrapper,
+    // The id of the event subscriber this object stands for.
+    subscriber_id: SubscriberId,
+}
+
+impl<'a> EventOps<'a> {
+    pub(crate) fn new(epoll_wrapper: &'a mut EpollWrapper, subscriber_id: SubscriberId) -> Self {
+        EventOps {
+            epoll_wrapper,
+            subscriber_id,
+        }
+    }
+
+    // Apply the provided control operation for the given events on the inner epoll wrapper.
+    fn ctl(&self, op: ControlOperation, events: Events) -> Result<()> {
+        self.epoll_wrapper
+            .epoll
+            .ctl(op, events.fd(), events.epoll_event())
+            .map_err(Error::Epoll)
+    }
+
+    /// Add the provided events to the inner epoll event set.
+    pub fn add(&mut self, events: Events) -> Result<()> {
+        let fd = events.fd();
+        if self.epoll_wrapper.fd_dispatch.contains_key(&fd) {
+            return Err(Error::FdAlreadyRegistered);
+        }
+
+        self.ctl(ControlOperation::Add, events)?;
+
+        self.epoll_wrapper
+            .fd_dispatch
+            .insert(fd, self.subscriber_id);
+
+        self.epoll_wrapper
+            .subscriber_watch_list
+            .entry(self.subscriber_id)
+            .or_insert_with(Vec::new)
+            .push(fd);
+
+        Ok(())
+    }
+
+    /// Submit the provided changes to the inner epoll event set.
+    pub fn modify(&self, events: Events) -> Result<()> {
+        self.ctl(ControlOperation::Modify, events)
+    }
+
+    /// Remove the specified events from the inner epoll event set.
+    pub fn remove(&mut self, events: Events) -> Result<()> {
+        // TODO: Add some more checks here?
+        self.ctl(ControlOperation::Delete, events)?;
+        self.epoll_wrapper.fd_dispatch.remove(&events.fd());
+
+        if let Some(watch_list) = self
+            .epoll_wrapper
+            .subscriber_watch_list
+            .get_mut(&self.subscriber_id)
+        {
+            if let Some(index) = watch_list.iter().position(|&x| x == events.fd()) {
+                watch_list.remove(index);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use vmm_sys_util::eventfd::EventFd;
+
+    #[test]
+    fn test_empty_events() {
+        let event_fd = EventFd::new(0).unwrap();
+
+        let events_raw = Events::empty_raw(event_fd.as_raw_fd());
+        let events = Events::empty(&event_fd);
+
+        assert_eq!(events, events_raw);
+
+        assert_eq!(events.event_set(), EventSet::empty());
+        assert_eq!(events.data(), 0);
+        assert_eq!(events.fd(), event_fd.as_raw_fd());
+    }
+
+    #[test]
+    fn test_events_no_data() {
+        let event_fd = EventFd::new(0).unwrap();
+        let event_set = EventSet::IN;
+
+        let events_raw = Events::new_raw(event_fd.as_raw_fd(), event_set);
+        let events = Events::new(&event_fd, event_set);
+
+        assert_eq!(events_raw, events);
+
+        assert_eq!(events.data(), 0);
+        assert_eq!(events.fd(), event_fd.as_raw_fd());
+        assert_eq!(events.event_set(), event_set);
+    }
+
+    #[test]
+    fn test_events_data() {
+        let event_fd = EventFd::new(0).unwrap();
+        let event_set = EventSet::IN;
+
+        let events_raw = Events::with_data_raw(event_fd.as_raw_fd(), 42, event_set);
+        let events = Events::with_data(&event_fd, 43, event_set);
+
+        assert_ne!(events_raw, events);
+
+        assert_eq!(events.data(), 43);
+        assert_eq!(events_raw.data(), 42);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,61 @@
-#![deny(missing_docs)]
-//! Dummy crate needs high-level documentation.
-/// Dummy public function needs documentation.
-pub fn it_works() {
-    assert!(true);
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io;
+use std::result;
+
+mod epoll;
+mod events;
+mod manager;
+mod subscribers;
+
+pub use events::{EventOps, Events};
+pub use manager::EventManager;
+
+#[cfg(feature = "remote_endpoint")]
+mod endpoint;
+#[cfg(feature = "remote_endpoint")]
+pub use endpoint::RemoteEndpoint;
+
+/// Error conditions that may appear during `EventManager` related operations.
+#[derive(Debug)]
+pub enum Error {
+    ChannelSend,
+    ChannelRecv,
+    Epoll(io::Error),
+    EventFd(io::Error),
+    // TODO: should we allow fds to be registered multiple times?
+    FdAlreadyRegistered,
+    InvalidId,
+}
+
+/// Generic result type that may return `EventManager` errors.
+pub type Result<T> = result::Result<T, Error>;
+
+/// Opaque object that uniquely represents a subscriber registered with an `EventManager`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct SubscriberId(u64);
+
+/// The `EventSubscriber` trait allows the interaction between an `EventManager` and different
+/// event subscribers.
+pub trait EventSubscriber {
+    /// Respond to events and potentially alter the interest set of the subscriber.
+    ///
+    /// Called by the `EventManager` whenever an event associated with the subscriber is triggered.
+    fn process(&mut self, events: Events, ops: &mut EventOps);
+
+    /// Register the events initially associated with the subscriber.
+    ///
+    /// Called by the `EventManager` after a subscriber is registered.
+    fn init(&mut self, ops: &mut EventOps);
+}
+
+/// Represents the part of the event event_manager API that allows users to add, remove, and
+/// otherwise interact with registered subscribers.
+pub trait SubscriberOps {
+    type Subscriber: EventSubscriber;
+
+    fn add_subscriber(&mut self, subscriber: Self::Subscriber) -> SubscriberId;
+    fn remove_subscriber(&mut self, subscriber_id: SubscriberId) -> Result<Self::Subscriber>;
+    fn subscriber_mut(&mut self, subscriber_id: SubscriberId) -> Result<&mut Self::Subscriber>;
+    fn control_ops(&mut self, subscriber_id: SubscriberId) -> Result<EventOps>;
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,432 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{Arc, Mutex};
+
+use vmm_sys_util::epoll::EpollEvent;
+#[cfg(feature = "remote_endpoint")]
+use vmm_sys_util::epoll::{ControlOperation, EventSet};
+
+#[cfg(feature = "remote_endpoint")]
+use super::endpoint::{EventManagerChannel, RemoteEndpoint};
+use super::epoll::EpollWrapper;
+use super::subscribers::Subscribers;
+use super::{Error, EventOps, EventSubscriber, Events, Result, SubscriberId, SubscriberOps};
+
+/// Allows event subscribers to be registered, connected to the event loop, and later removed.
+pub struct EventManager<T> {
+    subscribers: Subscribers<T>,
+    epoll_context: EpollWrapper,
+    ready_events: Vec<EpollEvent>,
+
+    #[cfg(feature = "remote_endpoint")]
+    channel: EventManagerChannel<T>,
+}
+
+impl<T: EventSubscriber> SubscriberOps for EventManager<T> {
+    type Subscriber = T;
+
+    /// Register a subscriber with the event event_manager and returns the associated ID.
+    fn add_subscriber(&mut self, subscriber: T) -> SubscriberId {
+        let subscriber_id = self.subscribers.add(subscriber);
+        self.subscribers
+            .get_mut_unchecked(subscriber_id)
+            // The index is valid because we've just added the subscriber.
+            .init(&mut self.epoll_context.ops_unchecked(subscriber_id));
+        subscriber_id
+    }
+
+    /// Unregisters and returns the subscriber associated with the provided ID.
+    fn remove_subscriber(&mut self, subscriber_id: SubscriberId) -> Result<T> {
+        let subscriber = self
+            .subscribers
+            .remove(subscriber_id)
+            .ok_or(Error::InvalidId)?;
+        self.epoll_context.remove(subscriber_id);
+        Ok(subscriber)
+    }
+
+    /// Return a mutable reference to the subscriber associated with the provided id.
+    fn subscriber_mut(&mut self, subscriber_id: SubscriberId) -> Result<&mut T> {
+        if self.subscribers.contains(subscriber_id) {
+            return Ok(self.subscribers.get_mut_unchecked(subscriber_id));
+        }
+        Err(Error::InvalidId)
+    }
+
+    /// Returns a `ControlOps` object for the subscriber associated with the provided ID.
+    fn control_ops(&mut self, subscriber_id: SubscriberId) -> Result<EventOps> {
+        // Check if the subscriber_id is valid.
+        if self.subscribers.contains(subscriber_id) {
+            // The index is valid because the result of `find` was not `None`.
+            return Ok(self.epoll_context.ops_unchecked(subscriber_id));
+        }
+        Err(Error::InvalidId)
+    }
+}
+
+// TODO: add implementations for other standard wrappers as well.
+impl EventSubscriber for Arc<Mutex<dyn EventSubscriber>> {
+    fn process(&mut self, events: Events, ops: &mut EventOps) {
+        self.lock().unwrap().process(events, ops);
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        self.lock().unwrap().init(ops);
+    }
+}
+
+impl<S: EventSubscriber> EventManager<S> {
+    /// Create a new `EventManger` object.
+    pub fn new() -> Result<Self> {
+        let manager = EventManager {
+            subscribers: Subscribers::new(),
+            epoll_context: EpollWrapper::new()?,
+            ready_events: vec![EpollEvent::default(); 256],
+            #[cfg(feature = "remote_endpoint")]
+            channel: EventManagerChannel::new()?,
+        };
+
+        #[cfg(feature = "remote_endpoint")]
+        manager
+            .epoll_context
+            .epoll
+            .ctl(
+                ControlOperation::Add,
+                manager.channel.fd(),
+                EpollEvent::new(EventSet::IN, manager.channel.fd() as u64),
+            )
+            .map_err(Error::Epoll)?;
+        Ok(manager)
+    }
+
+    /// Run the event loop blocking until the first batch of events.
+    // Using the current run interface, not sure if the best but that's another discussion.
+    pub fn run(&mut self) -> Result<usize> {
+        self.run_with_timeout(-1)
+    }
+
+    /// Wait for events for a maximum timeout of `miliseconds`. Dispatch the events to the
+    /// registered signal handlers.
+    pub fn run_with_timeout(&mut self, milliseconds: i32) -> Result<usize> {
+        let event_count = self
+            .epoll_context
+            .epoll
+            .wait(
+                self.ready_events.len(),
+                milliseconds,
+                &mut self.ready_events[..],
+            )
+            .map_err(Error::Epoll)?;
+        self.dispatch_events(event_count);
+
+        Ok(event_count)
+    }
+
+    fn dispatch_events(&mut self, event_count: usize) {
+        // Use the temporary, pre-allocated buffer to check ready events.
+        for ev_index in 0..event_count {
+            let event = self.ready_events[ev_index];
+
+            #[cfg(feature = "remote_endpoint")]
+            {
+                if self.dispatch_endpoint_event(event) {
+                    continue;
+                }
+            }
+
+            let fd = event.fd();
+            // This error condition can happen when the fd associated with a subscriber was closed,
+            // and the subscriber did not handle the RHUP/
+            let subscriber_id = self
+                .epoll_context
+                .subscriber_id(fd)
+                .expect("Received event on fd from subscriber that does not exist");
+
+            self.subscribers.get_mut_unchecked(subscriber_id).process(
+                Events::with_inner(event),
+                // The `subscriber_id` is valid because we checked it before.
+                &mut self.epoll_context.ops_unchecked(subscriber_id),
+            );
+        }
+    }
+}
+
+#[cfg(feature = "remote_endpoint")]
+impl<S: EventSubscriber> EventManager<S> {
+    /// Return a `RemoteEndpoint` object, that allows interacting with the `EventManager` from a
+    /// different thread. Using `RemoteEndpoint::call_blocking` on the same thread the event loop
+    /// runs on leads to a deadlock.
+    pub fn remote_endpoint(&self) -> RemoteEndpoint<S> {
+        self.channel.remote_endpoint()
+    }
+
+    // Returns true if there are any endpoints to be dispatched.
+    fn dispatch_endpoint_event(&mut self, event: EpollEvent) -> bool {
+        if event.fd() == self.channel.fd() {
+            if event.event_set() != EventSet::IN {
+                // This situation is virtually impossible to occur. If it does we have
+                // a programming error in our code.
+                unreachable!();
+            }
+            self.handle_endpoint_calls();
+            return true;
+        }
+        false
+    }
+
+    fn handle_endpoint_calls(&mut self) {
+        // Clear the inner event_fd. We don't do anything about an error here at this point.
+        let _ = self.channel.event_fd.read();
+
+        // Process messages. We consider only `Empty` errors can appear here; we don't check
+        // for `Disconnected` errors because we keep at least one clone of `channel.sender` alive
+        // at all times ourselves.
+        while let Ok(msg) = self.channel.receiver.try_recv() {
+            // We call the inner closure and attempt to send back the result, but can't really do
+            // anything in case of error here.
+            let _ = msg.sender.send((msg.fnbox)(self));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::os::unix::io::{AsRawFd, RawFd};
+    use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
+
+    struct DummySubscriber {
+        event_fd_1: EventFd,
+        event_fd_2: EventFd,
+
+        // Flags used for checking that the event event_manager called the `process`
+        // function for ev1/ev2.
+        processed_ev1_out: bool,
+        processed_ev2_out: bool,
+        processed_ev1_in: bool,
+
+        // Flags used for driving register/unregister/modify of events from
+        // outside of the `process` function.
+        register_ev2: bool,
+        unregister_ev1: bool,
+        modify_ev1: bool,
+    }
+
+    impl DummySubscriber {
+        fn new() -> Self {
+            DummySubscriber {
+                event_fd_1: EventFd::new(0).unwrap(),
+                event_fd_2: EventFd::new(0).unwrap(),
+                processed_ev1_out: false,
+                processed_ev2_out: false,
+                processed_ev1_in: false,
+                register_ev2: false,
+                unregister_ev1: false,
+                modify_ev1: false,
+            }
+        }
+    }
+
+    impl DummySubscriber {
+        fn register_ev2(&mut self) {
+            self.register_ev2 = true;
+        }
+
+        fn unregister_ev1(&mut self) {
+            self.unregister_ev1 = true;
+        }
+
+        fn modify_ev1(&mut self) {
+            self.modify_ev1 = true;
+        }
+
+        fn processed_ev1_out(&self) -> bool {
+            self.processed_ev1_out
+        }
+
+        fn processed_ev2_out(&self) -> bool {
+            self.processed_ev2_out
+        }
+
+        fn processed_ev1_in(&self) -> bool {
+            self.processed_ev1_in
+        }
+
+        fn reset_state(&mut self) {
+            self.processed_ev1_out = false;
+            self.processed_ev2_out = false;
+            self.processed_ev1_in = false;
+        }
+
+        fn handle_updates(&mut self, event_manager: &mut EventOps) {
+            if self.register_ev2 {
+                event_manager
+                    .add(Events::new(&self.event_fd_2, EventSet::OUT))
+                    .unwrap();
+                self.register_ev2 = false;
+            }
+
+            if self.unregister_ev1 {
+                event_manager
+                    .remove(Events::new_raw(
+                        self.event_fd_1.as_raw_fd(),
+                        EventSet::empty(),
+                    ))
+                    .unwrap();
+                self.unregister_ev1 = false;
+            }
+
+            if self.modify_ev1 {
+                event_manager
+                    .modify(Events::new(&self.event_fd_1, EventSet::IN))
+                    .unwrap();
+                self.modify_ev1 = false;
+            }
+        }
+
+        fn handle_in(&mut self, source: RawFd) {
+            if self.event_fd_1.as_raw_fd() == source {
+                self.processed_ev1_in = true;
+            }
+        }
+
+        fn handle_out(&mut self, source: RawFd) {
+            match source {
+                _ if self.event_fd_1.as_raw_fd() == source => {
+                    self.processed_ev1_out = true;
+                }
+                _ if self.event_fd_2.as_raw_fd() == source => {
+                    self.processed_ev2_out = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    impl EventSubscriber for DummySubscriber {
+        fn process(&mut self, events: Events, ops: &mut EventOps) {
+            let source = events.fd();
+            let event_set = events.event_set();
+
+            // We only know how to treat EPOLLOUT and EPOLLIN.
+            // If we received anything else just stop processing the event.
+            let all_but_in_out = EventSet::all() - EventSet::OUT - EventSet::IN;
+            if event_set.intersects(all_but_in_out) {
+                return;
+            }
+
+            self.handle_updates(ops);
+
+            match event_set {
+                EventSet::IN => self.handle_in(source),
+                EventSet::OUT => self.handle_out(source),
+                _ => {}
+            }
+        }
+
+        fn init(&mut self, ops: &mut EventOps) {
+            let event = Events::new(&self.event_fd_1, EventSet::OUT);
+            ops.add(event).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_register() {
+        use super::SubscriberOps;
+
+        let mut event_manager = EventManager::<Arc<Mutex<dyn EventSubscriber>>>::new().unwrap();
+        let dummy_subscriber = Arc::new(Mutex::new(DummySubscriber::new()));
+
+        event_manager.add_subscriber(dummy_subscriber.clone());
+
+        dummy_subscriber.lock().unwrap().register_ev2();
+
+        // When running the loop the first time, ev1 should be processed, but ev2 shouldn't
+        // because it was just added as part of processing ev1.
+        event_manager.run().unwrap();
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_out(), true);
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev2_out(), false);
+
+        // Check that both ev1 and ev2 are processed.
+        dummy_subscriber.lock().unwrap().reset_state();
+        event_manager.run().unwrap();
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_out(), true);
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev2_out(), true);
+    }
+
+    // Test that unregistering an event while processing another one works.
+    #[test]
+    fn test_unregister() {
+        let mut event_manager = EventManager::<Arc<Mutex<dyn EventSubscriber>>>::new().unwrap();
+        let dummy_subscriber = Arc::new(Mutex::new(DummySubscriber::new()));
+
+        event_manager.add_subscriber(dummy_subscriber.clone());
+
+        // Disable ev1. We should only receive this event once.
+        dummy_subscriber.lock().unwrap().unregister_ev1();
+
+        event_manager.run().unwrap();
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_out(), true);
+
+        dummy_subscriber.lock().unwrap().reset_state();
+
+        // We expect no events to be available. Let's run with timeout so that run exists.
+        event_manager.run_with_timeout(100).unwrap();
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_out(), false);
+    }
+
+    #[test]
+    fn test_modify() {
+        let mut event_manager = EventManager::<Arc<Mutex<dyn EventSubscriber>>>::new().unwrap();
+        let dummy_subscriber = Arc::new(Mutex::new(DummySubscriber::new()));
+
+        event_manager.add_subscriber(dummy_subscriber.clone());
+
+        // Modify ev1 so that it waits for EPOLL_IN.
+        dummy_subscriber.lock().unwrap().modify_ev1();
+        event_manager.run().unwrap();
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_out(), true);
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev2_out(), false);
+
+        dummy_subscriber.lock().unwrap().reset_state();
+
+        // Make sure ev1 is ready for IN so that we don't loop forever.
+        dummy_subscriber
+            .lock()
+            .unwrap()
+            .event_fd_1
+            .write(1)
+            .unwrap();
+
+        event_manager.run().unwrap();
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_out(), false);
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev2_out(), false);
+        assert_eq!(dummy_subscriber.lock().unwrap().processed_ev1_in(), true);
+    }
+
+    #[test]
+    #[cfg(feature = "remote_endpoint")]
+    fn test_endpoint() {
+        use std::thread;
+
+        let mut event_manager = EventManager::<DummySubscriber>::new().unwrap();
+        let dummy = DummySubscriber::new();
+        let endpoint = event_manager.remote_endpoint();
+
+        let thread_handle = thread::spawn(move || {
+            event_manager.run().unwrap();
+        });
+
+        dummy.event_fd_1.write(1).unwrap();
+
+        let token = endpoint
+            .call_blocking(|sub_ops| -> Result<SubscriberId> { Ok(sub_ops.add_subscriber(dummy)) })
+            .unwrap();
+
+        assert_eq!(token, SubscriberId(1));
+
+        thread_handle.join().unwrap();
+    }
+}

--- a/src/subscribers.rs
+++ b/src/subscribers.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use super::SubscriberId;
+use std::collections::HashMap;
+
+// Internal structure used to keep the set of subscribers registered with an EventManger.
+// This structure is a thin wrapper over a `HashMap` in which the keys are uniquely
+// generated when calling `add`.
+pub(crate) struct Subscribers<T> {
+    // The key is the unique id of the subscriber and the entry is the `Subscriber`.
+    subscribers: HashMap<SubscriberId, T>,
+    // We are generating the unique ids by incrementing this counter for each added subscriber,
+    // and rely on the large value range of u64 to ensure each value is effectively
+    // unique over the runtime of any VMM.
+    next_id: u64,
+}
+
+impl<T> Subscribers<T> {
+    pub(crate) fn new() -> Self {
+        Subscribers {
+            subscribers: HashMap::new(),
+            next_id: 1,
+        }
+    }
+
+    // Adds a subscriber and generates an unique id to represent it.
+    pub(crate) fn add(&mut self, subscriber: T) -> SubscriberId {
+        let id = SubscriberId(self.next_id);
+        self.next_id += 1;
+
+        self.subscribers.insert(id, subscriber);
+
+        id
+    }
+
+    // Remove and return the subscriber associated with the given id, if it exists.
+    pub(crate) fn remove(&mut self, subscriber_id: SubscriberId) -> Option<T> {
+        self.subscribers.remove(&subscriber_id)
+    }
+
+    // Checks whether a subscriber with `subscriber_id` is registered.
+    pub(crate) fn contains(&mut self, subscriber_id: SubscriberId) -> bool {
+        self.subscribers.contains_key(&subscriber_id)
+    }
+
+    // Return a mutable reference to the subriber represented by `subscriber_id`.
+    //
+    // This method should only be called for indices that are known to be valid, otherwise
+    // panics can occur.
+    pub(crate) fn get_mut_unchecked(&mut self, subscriber_id: SubscriberId) -> &mut T {
+        self.subscribers.get_mut(&subscriber_id).unwrap()
+    }
+}


### PR DESCRIPTION
Added an initial implementation of vmm-epoll. This is loosely based on the implementation we have in Firecracker (at the interface level), but goes further into fixing some loose ends described in this comment: https://github.com/rust-vmm/vmm-epoll/pull/2#issuecomment-586204636