### PR TITLE
added integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ without the need of more intrusive synchronization.
 
 ## Examples
 
-For closer to real life use cases, please check
-[TODO actual code examples](this).
+For closer to real life use cases, please check the examples in
+[tests](tests).
 
 ### Basic Single Thread Subscriber
 

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 93.5,
-  "exclude_path": "",
+  "exclude_path": "tests/",
   "crate_features": "remote_endpoint"
 }

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 93.5,
   "exclude_path": "",
-  "crate_features": ""
+  "crate_features": "remote_endpoint"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 93.7,
-  "exclude_path": "",
+  "exclude_path": "tests/",
   "crate_features": "remote_endpoint"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 96.2,
+  "coverage_score": 93.7,
   "exclude_path": "",
-  "crate_features": ""
+  "crate_features": "remote_endpoint"
 }

--- a/tests/basic_event_manager.rs
+++ b/tests/basic_event_manager.rs
@@ -1,0 +1,114 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+// A basic, single threaded application that only needs one type of
+// subscriber: `CounterSubscriber`.
+//
+// The application has an `EventManager` and can register multiple subscribers
+// of type `CounterSubscriber`.
+extern crate event_manager;
+extern crate vmm_sys_util;
+
+mod subscribers;
+
+use event_manager::{EventManager, SubscriberId, SubscriberOps};
+use std::ops::Drop;
+use subscribers::CounterSubscriber;
+
+struct App {
+    event_manager: EventManager<CounterSubscriber>,
+    subscribers_id: Vec<SubscriberId>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            event_manager: EventManager::<CounterSubscriber>::new().unwrap(),
+            subscribers_id: vec![],
+        }
+    }
+
+    fn add_subscriber(&mut self) {
+        let counter_subscriber = CounterSubscriber::new();
+        let id = self.event_manager.add_subscriber(counter_subscriber);
+        self.subscribers_id.push(id);
+    }
+
+    fn run(&mut self) {
+        let _ = self.event_manager.run_with_timeout(100);
+    }
+
+    fn inject_events_for(&mut self, subscriber_index: &[usize]) {
+        for i in subscriber_index {
+            let subscriber = self
+                .event_manager
+                .subscriber_mut(self.subscribers_id[*i])
+                .unwrap();
+            subscriber.trigger_event();
+        }
+    }
+
+    fn clear_events_for(&mut self, subscriber_indices: &[usize]) {
+        for i in subscriber_indices {
+            let subscriber = self
+                .event_manager
+                .subscriber_mut(self.subscribers_id[*i])
+                .unwrap();
+            subscriber.clear_event();
+        }
+    }
+
+    fn get_counters(&mut self) -> Vec<u64> {
+        let mut result = Vec::<u64>::new();
+        for subscriber_id in &self.subscribers_id {
+            let subscriber = self.event_manager.subscriber_mut(*subscriber_id).unwrap();
+            result.push(subscriber.counter());
+        }
+
+        result
+    }
+
+    // Whenever the App does not need to monitor events anymore, it should explicitly call
+    // the `remove_subscriber` function.
+    fn cleanup(&mut self) {
+        for id in &self.subscribers_id {
+            let _ = self.event_manager.remove_subscriber(*id);
+        }
+    }
+}
+
+impl Drop for App {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+#[test]
+fn test_single_threaded() {
+    let mut app = App::new();
+    for _ in 0..100 {
+        app.add_subscriber();
+    }
+
+    // Random subscribers, in the sense that I randomly picked those numbers :)
+    let triggered_subscribers: Vec<usize> = vec![1, 3, 50, 97];
+    app.inject_events_for(&triggered_subscribers);
+    app.run();
+
+    let counters = app.get_counters();
+    for i in 0..100 {
+        assert_eq!(counters[i], 1 & (triggered_subscribers.contains(&i) as u64));
+    }
+
+    app.clear_events_for(&triggered_subscribers);
+    app.run();
+    let counters = app.get_counters();
+    for i in 0..100 {
+        assert_eq!(counters[i], 1 & (triggered_subscribers.contains(&i) as u64));
+    }
+
+    // Once the app does not need events anymore, the cleanup needs to be called.
+    // This is particularly important when the app continues the execution, but event monitoring
+    // is not necessary.
+    app.cleanup();
+}

--- a/tests/multi_threaded.rs
+++ b/tests/multi_threaded.rs
@@ -1,0 +1,148 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+mod subscribers;
+
+use event_manager::{EventManager, EventSubscriber, MutEventSubscriber, SubscriberOps};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use subscribers::{CounterInnerMutSubscriber, CounterSubscriber, CounterSubscriberWithData};
+
+// Showcase how you can manage subscribers of different types using the same event manager
+// in a multithreaded context.
+#[test]
+fn test_diff_type_subscribers() {
+    let mut event_manager = EventManager::<Arc<Mutex<dyn MutEventSubscriber + Send>>>::new()
+        .expect("Cannot create event manager.");
+
+    // The `CounterSubscriberWithData` expects to receive a number as a parameter that represents
+    // the number it can use as its inner Events data.
+    let data_subscriber = Arc::new(Mutex::new(CounterSubscriberWithData::new(1)));
+    data_subscriber.lock().unwrap().trigger_all_counters();
+
+    let counter_subscriber = Arc::new(Mutex::new(CounterSubscriber::new()));
+    counter_subscriber.lock().unwrap().trigger_event();
+
+    // Saving the ids allows to modify the subscribers in the event manager context (i.e. removing
+    // the subscribers from the event manager loop).
+    let ds_id = event_manager.add_subscriber(data_subscriber);
+    let cs_id = event_manager.add_subscriber(counter_subscriber);
+
+    let thread_handle = thread::spawn(move || {
+        // In a typical application this would be an infinite loop with some break condition.
+        // For tests, 100 iterations should suffice.
+        for _ in 0..100 {
+            // When the event manager loop exits, it will return the number of events it
+            // handled.
+            let ev_count = event_manager.run().unwrap();
+            // We are expecting the ev_count to be:
+            // 4 = 3 (events triggered from data_subscriber) + 1 (event from counter_subscriber).
+            assert_eq!(ev_count, 4);
+        }
+
+        // One really important thing is to always remove the subscribers once you don't need them
+        // any more.
+        let _ = event_manager.remove_subscriber(ds_id).unwrap();
+        let _ = event_manager.remove_subscriber(cs_id).unwrap();
+    });
+    thread_handle.join().unwrap();
+}
+
+// Showcase how you can manage a single type of subscriber using the same event manager
+// in a multithreaded context.
+#[test]
+fn test_one_type_subscriber() {
+    let mut event_manager =
+        EventManager::<CounterSubscriberWithData>::new().expect("Cannot create event manager");
+
+    // The `CounterSubscriberWithData` expects to receive the number it can use as its inner
+    // `Events` data as a parameter.
+    // Let's make sure that the inner data of the two subscribers will not overlap by keeping some
+    //  numbers between the first_data of each subscriber.
+    let data_subscriber_1 = CounterSubscriberWithData::new(1);
+    let data_subscriber_2 = CounterSubscriberWithData::new(1999);
+
+    // Saving the ids allows to modify the subscribers in the event manager context (i.e. removing
+    // the subscribers from the event manager loop).
+    let ds_id_1 = event_manager.add_subscriber(data_subscriber_1);
+    let ds_id_2 = event_manager.add_subscriber(data_subscriber_2);
+
+    // Since we moved the ownership of the subscriber to the event manager, now we need to get
+    // a mutable reference from it so that we can modify them.
+    // Enclosing this in a code block so that the references are dropped when they're no longer
+    // needed.
+    {
+        let data_subscriber_1 = event_manager.subscriber_mut(ds_id_1).unwrap();
+        data_subscriber_1.trigger_all_counters();
+
+        let data_subscriber_2 = event_manager.subscriber_mut(ds_id_2).unwrap();
+        data_subscriber_2.trigger_all_counters();
+    }
+
+    let thread_handle = thread::spawn(move || {
+        // In a typical application this would be an infinite loop with some break condition.
+        // For tests, 100 iterations should suffice.
+        for _ in 0..100 {
+            // When the event manager loop exits, it will return the number of events it
+            // handled.
+            let ev_count = event_manager.run().unwrap();
+            // Since we triggered all counters, we're expecting the number of events to always be
+            // 6 (3 from one subscriber and 3 from the other).
+            assert_eq!(ev_count, 6);
+        }
+
+        // One really important thing is to always remove the subscribers once you don't need them
+        // any more.
+        // When calling remove_subscriber, you receive ownership of the subscriber object.
+        let data_subscriber_1 = event_manager.remove_subscriber(ds_id_1).unwrap();
+        let data_subscriber_2 = event_manager.remove_subscriber(ds_id_2).unwrap();
+
+        // Let's check how the subscribers look after 100 iterations.
+        // Each subscriber's counter start from 0. When an event is triggered, each counter
+        // is incremented. So after 100 iterations when they're all triggered, we expect them
+        // to be 100.
+        let expected_subscriber_counters = vec![100, 100, 100];
+        assert_eq!(
+            data_subscriber_1.get_all_counter_values(),
+            expected_subscriber_counters
+        );
+        assert_eq!(
+            data_subscriber_2.get_all_counter_values(),
+            expected_subscriber_counters
+        );
+    });
+
+    thread_handle.join().unwrap();
+}
+
+// Showcase how you can manage subscribers that make use of inner mutability using the event manager
+// in a multithreaded context.
+#[test]
+fn test_subscriber_inner_mut() {
+    // We are using just the `CounterInnerMutSubscriber` subscriber, so we could've initialize
+    // the event manager as: EventManager::<CounterInnerMutSubscriber>::new().
+    // The typical application will have more than one subscriber type, so let's just pretend
+    // this is the case in this example as well.
+    let mut event_manager = EventManager::<Arc<dyn EventSubscriber + Send + Sync>>::new()
+        .expect("Cannot create event manager");
+
+    let subscriber = Arc::new(CounterInnerMutSubscriber::new());
+    subscriber.trigger_event();
+
+    // Let's just clone the subscriber before adding it to the event manager. This will allow us
+    // to use it from this thread without the need to call into EventManager::subscriber_mut().
+    let subscriber_id = event_manager.add_subscriber(subscriber.clone());
+
+    let thread_handle = thread::spawn(move || {
+        for _ in 0..100 {
+            // When the event manager loop exits, it will return the number of events it
+            // handled.
+            let ev_count = event_manager.run().unwrap();
+            assert_eq!(ev_count, 1);
+        }
+
+        assert!(event_manager.remove_subscriber(subscriber_id).is_ok());
+    });
+    thread_handle.join().unwrap();
+
+    assert_eq!(subscriber.counter(), 100);
+}

--- a/tests/subscribers/mod.rs
+++ b/tests/subscribers/mod.rs
@@ -1,0 +1,279 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+// Cargo thinks that some of the methods in this module are not used because
+// not all of them are used in all the separate integration test modules.
+// Cargo bug: https://github.com/rust-lang/rust/issues/46379
+// Let's allow dead code so that we don't get warnings all the time.
+#![allow(dead_code)]
+/// This module defines common subscribers that showcase the usage of the event-manager.
+///
+/// 1. CounterSubscriber:
+///     - a dummy subscriber that increments a counter on event
+///     - only uses one event
+///     - it has to be explicitly mutated; for this reason it implements `MutEventSubscriber`.
+///
+/// 2. CounterSubscriberWithData:
+///     - a dummy subscriber that increments a counter on events
+///     - this subscriber takes care of multiple events and makes use of `Events::with_data` so
+///       that in the `process` function it identifies the trigger of an event using the data
+///       instead of the file descriptor
+///     - it has to be explicitly mutated; for this reason it implements `MutEventSubscriber`.
+///
+/// 3. CounterInnerMutSubscriber:
+///     - a dummy subscriber that increments a counter on events
+///     - the subscriber makes use of inner mutability; multi-threaded applications might want to
+///       use inner mutability instead of having something heavy weight (i.e. Arc<Mutex>).
+///     - this subscriber implement `EventSubscriber`.
+use event_manager::{EventOps, EventSubscriber, Events, MutEventSubscriber};
+use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
+
+use std::fmt::{Display, Formatter, Result};
+use std::os::unix::io::AsRawFd;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// A `Counter` is a helper structure for creating subscribers that increment a value
+/// each time an event is triggered.
+/// The `Counter` allows users to assert and de-assert an event, and to query the counter value.
+pub struct Counter {
+    event_fd: EventFd,
+    counter: u64,
+}
+
+impl Display for Counter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "(event_fd = {}, counter = {})",
+            self.event_fd.as_raw_fd(),
+            self.counter
+        )
+    }
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self {
+            event_fd: EventFd::new(0).unwrap(),
+            counter: 0,
+        }
+    }
+
+    pub fn trigger_event(&mut self) {
+        let _ = self.event_fd.write(1);
+    }
+
+    pub fn clear_event(&self) {
+        let _ = self.event_fd.read();
+    }
+
+    pub fn counter(&self) -> u64 {
+        self.counter
+    }
+}
+
+impl Default for Counter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// A dummy subscriber that increments a counter whenever it processes
+// a new request.
+pub struct CounterSubscriber(Counter);
+
+impl std::ops::Deref for CounterSubscriber {
+    type Target = Counter;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for CounterSubscriber {
+    fn deref_mut(&mut self) -> &mut Counter {
+        &mut self.0
+    }
+}
+
+impl CounterSubscriber {
+    pub fn new() -> Self {
+        CounterSubscriber(Counter::new())
+    }
+}
+
+impl MutEventSubscriber for CounterSubscriber {
+    fn process(&mut self, events: Events, event_ops: &mut EventOps) {
+        match events.event_set() {
+            EventSet::IN => {
+                self.counter += 1;
+            }
+            EventSet::ERROR => {
+                eprintln!("Got error on the monitored event.");
+            }
+            EventSet::HANG_UP => {
+                event_ops
+                    .remove(events)
+                    .unwrap_or(eprintln!("Encountered error during cleanup"));
+                panic!("Cannot continue execution. Associated fd was closed.");
+            }
+            _ => {
+                eprintln!(
+                    "Received spurious event from the event manager {:#?}.",
+                    events.event_set()
+                );
+            }
+        }
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        ops.add(Events::new(&self.event_fd, EventSet::IN))
+            .expect("Cannot register event.");
+    }
+}
+
+// A dummy subscriber that makes use of the optional data in `Events` when
+// registering & processing events.
+// Using 3 counters each having associated event data to showcase the implementation of
+// EventSubscriber trait with this scenario.
+pub struct CounterSubscriberWithData {
+    counter_1: Counter,
+    counter_2: Counter,
+    counter_3: Counter,
+
+    first_data: u32,
+}
+
+impl CounterSubscriberWithData {
+    // `first_data` represents the first event data that can be used by this subscriber.
+    pub fn new(first_data: u32) -> Self {
+        Self {
+            counter_1: Counter::new(),
+            counter_2: Counter::new(),
+            counter_3: Counter::new(),
+            // Using consecutive numbers for the event data helps the compiler to optimize
+            // match statements on counter_1_data, counter_2_data, counter_3_data using
+            // a jump table.
+            first_data,
+        }
+    }
+
+    pub fn trigger_all_counters(&mut self) {
+        self.counter_1.trigger_event();
+        self.counter_2.trigger_event();
+        self.counter_3.trigger_event();
+    }
+
+    pub fn get_all_counter_values(&self) -> Vec<u64> {
+        vec![
+            self.counter_1.counter(),
+            self.counter_2.counter(),
+            self.counter_3.counter(),
+        ]
+    }
+}
+
+impl MutEventSubscriber for CounterSubscriberWithData {
+    fn process(&mut self, events: Events, ops: &mut EventOps) {
+        match events.event_set() {
+            EventSet::IN => {
+                let event_id = events.data() - self.first_data;
+                match event_id {
+                    0 => {
+                        self.counter_1.counter += 1;
+                    }
+                    1 => {
+                        self.counter_2.counter += 1;
+                    }
+                    2 => {
+                        self.counter_3.counter += 1;
+                    }
+                    _ => {
+                        eprintln!("Received spurious event.");
+                    }
+                };
+            }
+            EventSet::ERROR => {
+                eprintln!("Got error on the monitored event.");
+            }
+            EventSet::HANG_UP => {
+                ops.remove(events)
+                    .unwrap_or(eprintln!("Encountered error during cleanup"));
+                panic!("Cannot continue execution. Associated fd was closed.");
+            }
+            _ => {}
+        }
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        ops.add(Events::with_data(
+            &self.counter_1.event_fd,
+            self.first_data,
+            EventSet::IN,
+        ))
+        .expect("Cannot register event.");
+        ops.add(Events::with_data(
+            &self.counter_2.event_fd,
+            self.first_data + 1,
+            EventSet::IN,
+        ))
+        .expect("Cannot register event.");
+        ops.add(Events::with_data(
+            &self.counter_3.event_fd,
+            self.first_data + 2,
+            EventSet::IN,
+        ))
+        .expect("Cannot register event.");
+    }
+}
+
+pub struct CounterInnerMutSubscriber {
+    event_fd: EventFd,
+    counter: AtomicU64,
+}
+
+impl CounterInnerMutSubscriber {
+    pub fn new() -> Self {
+        Self {
+            event_fd: EventFd::new(0).unwrap(),
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    pub fn trigger_event(&self) {
+        let _ = self.event_fd.write(1);
+    }
+
+    pub fn clear_event(&self) {
+        let _ = self.event_fd.read();
+    }
+
+    pub fn counter(&self) -> u64 {
+        self.counter.load(Ordering::Relaxed)
+    }
+}
+
+impl EventSubscriber for CounterInnerMutSubscriber {
+    fn process(&self, events: Events, ops: &mut EventOps) {
+        match events.event_set() {
+            EventSet::IN => {
+                self.counter.fetch_add(1, Ordering::Relaxed);
+            }
+            EventSet::ERROR => {
+                eprintln!("Got error on the monitored event.");
+            }
+            EventSet::HANG_UP => {
+                ops.remove(events)
+                    .unwrap_or(eprintln!("Encountered error during cleanup"));
+                panic!("Cannot continue execution. Associated fd was closed.");
+            }
+            _ => {}
+        }
+    }
+
+    fn init(&self, ops: &mut EventOps) {
+        ops.add(Events::new(&self.event_fd, EventSet::IN))
+            .expect("Cannot register event.");
+    }
+}


### PR DESCRIPTION
Added integration tests that cover single & multi-threaded
applications.

The integration tests make use of common subscribers defined
in the tests/common module.

The tests are also linked as examples in the README and should
be a good starting point for using the event-manager.

Fixes: https://github.com/rust-vmm/event-manager/issues/5

Signed-off-by: Andreea Florescu <fandree@amazon.com>