### PR TITLE
Add fire()/kick() to event manager

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 93.7,
+  "coverage_score": 86.1,
   "exclude_path": "tests/",
   "crate_features": "remote_endpoint"
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -44,7 +44,7 @@ pub(crate) struct FnMsg<S> {
     // The closure to execute.
     pub(crate) fnbox: FnOnceBox<S>,
     // The sending endpoint of the channel used by the remote called to wait for the result.
-    pub(crate) sender: Sender<ErasedResult>,
+    pub(crate) sender: Option<Sender<ErasedResult>>,
 }
 
 // Used by the `EventManager` to keep state associated with the channel.
@@ -124,7 +124,10 @@ impl<S: MutEventSubscriber> RemoteEndpoint<S> {
         );
 
         // Send the message requesting the closure invocation.
-        self.send(FnMsg { fnbox, sender })?;
+        self.send(FnMsg {
+            fnbox,
+            sender: Some(sender),
+        })?;
 
         // Block until a response is received. We can use unwrap because the downcast cannot fail,
         // since the signature of F (more specifically, the return value) constrains the concrete
@@ -138,5 +141,38 @@ impl<S: MutEventSubscriber> RemoteEndpoint<S> {
         // Turns out the dereference operator has a special behaviour for boxed objects; if we
         // own a `b: Box<T>` and call `*b`, the box goes away and we get the `T` inside.
         *result_box
+    }
+
+    /// Call the specified closure on the associated local/remote `EventManager` (provided as a
+    /// `SubscriberOps` trait object), and discard the result. This method only fires
+    /// the request but do not wait for result, so it may be called from the same thread where
+    /// the event loop runs.
+    pub fn fire<F>(&self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut dyn SubscriberOps<Subscriber = S>) + Send + 'static,
+    {
+        // We erase the return type of `f` by moving and calling it inside another closure which
+        // hides the result as an `ErasedResult`. This allows using the same channel send closures
+        // with different signatures (and thus different types) to the remote `EventManager`.
+        let fnbox = Box::new(
+            move |ops: &mut dyn SubscriberOps<Subscriber = S>| -> ErasedResult {
+                f(ops);
+                Box::new(())
+            },
+        );
+
+        // Send the message requesting the closure invocation.
+        self.send(FnMsg {
+            fnbox,
+            sender: None,
+        })
+    }
+
+    /// Kick the worker thread to wake up from the epoll event loop.
+    pub fn kick(&self) -> Result<()> {
+        self.event_fd
+            .write(1)
+            .map(|_| ())
+            .map_err(|e| Error::EventFd(Errno::from(e)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ use std::sync::{Arc, Mutex};
 
 use vmm_sys_util::errno::Error as Errno;
 
+/// The type of epoll events we can monitor a file descriptor for.
+pub use vmm_sys_util::epoll::EventSet;
+
 mod epoll;
 mod events;
 mod manager;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,49 @@ pub enum Error {
     InvalidId,
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "remote_endpoint")]
+            Error::ChannelSend => write!(
+                f,
+                "event_manager: failed to send message to remote endpoint"
+            ),
+            #[cfg(feature = "remote_endpoint")]
+            Error::ChannelRecv => write!(
+                f,
+                "event_manager: failed to receive message from remote endpoint"
+            ),
+            #[cfg(feature = "remote_endpoint")]
+            Error::EventFd(_e) => {
+                write!(f, "event_manager: failed to manage EventFd file descriptor")
+            }
+            Error::Epoll(_e) => write!(f, "event_manager: failed to manage epoll file descriptor"),
+            Error::FdAlreadyRegistered => write!(
+                f,
+                "event_manager: file descriptor has already been registered"
+            ),
+            Error::InvalidId => write!(f, "event_manager: invalid subscriber Id"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            #[cfg(feature = "remote_endpoint")]
+            Error::ChannelSend => None,
+            #[cfg(feature = "remote_endpoint")]
+            Error::ChannelRecv => None,
+            #[cfg(feature = "remote_endpoint")]
+            Error::EventFd(e) => Some(e),
+            Error::Epoll(e) => Some(e),
+            Error::FdAlreadyRegistered => None,
+            Error::InvalidId => None,
+        }
+    }
+}
+
 /// Generic result type that may return `EventManager` errors.
 pub type Result<T> = result::Result<T, Error>;
 


### PR DESCRIPTION
Several enhancements generated when integrating with the event-manager crate.
Reopen for #27 from a suitable forked repository.