### PR TITLE
Peformance Tests

### DIFF
--- a/.buildkite/custom-pipeline.yml
+++ b/.buildkite/custom-pipeline.yml
@@ -78,3 +78,31 @@ steps:
           privileged: true
           image: "rustvmm/dev:v6"
           always-pull: true
+
+  - label: "performance-x86"
+    commands:
+      - pytest rust-vmm-ci/integration_tests/test_benchmark.py
+    retry:
+      automatic: false
+    agents:
+      platform: x86_64.metal
+      os: linux
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v6"
+          always-pull: true
+          propagate-environment: true
+
+  - label: "performance-arm"
+    commands:
+      - pytest rust-vmm-ci/integration_tests/test_benchmark.py
+    retry:
+      automatic: false
+    agents:
+      platform: arm.metal
+      os: linux
+    plugins:
+      - docker#v3.0.1:
+          image: "rustvmm/dev:v6"
+          always-pull: true
+          propagate-environment: true

--- a/.buildkite/custom-pipeline.yml
+++ b/.buildkite/custom-pipeline.yml
@@ -9,7 +9,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true
 
   - label: "build-musl-x86-remote_endpoint"
@@ -22,7 +22,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true
 
   - label: "build-gnu-arm-remote_endpoint"
@@ -35,7 +35,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true
 
   - label: "build-musl-arm-remote_endpoint"
@@ -48,7 +48,7 @@ steps:
       os: linux
     plugins:
       - docker#v3.0.1:
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true
 
   - label: "check-warnings-x86"
@@ -62,7 +62,7 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true
 
   - label: "check-warnings-arm"
@@ -76,5 +76,5 @@ steps:
     plugins:
       - docker#v3.0.1:
           privileged: true
-          image: "rustvmm/dev:v5"
+          image: "rustvmm/dev:v6"
           always-pull: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,20 @@ edition = "2018"
 vmm-sys-util = ">=0.6.0"
 libc = ">=0.2.39"
 
+[dev-dependencies]
+criterion = "0.3.0"
+
 [features]
 remote_endpoint = []
 test_utilities = []
+
+[[bench]]
+name = "main"
+harness = false
+
+[lib]
+bench = false # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+
+[profile.bench]
+lto = true
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ libc = ">=0.2.39"
 
 [features]
 remote_endpoint = []
+test_utilities = []

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ impl App {
     }
 }
 ```
+
+## Development and Testing
+
+The `event-manager` is tested using unit tests, Rust integration tests and
+performance benchmarks. It leverages
+[`rust-vmm-ci`](https://github.com/rust-vmm/rust-vmm-ci) for continuous
+testing. All tests are run in the `rustvmm/dev` container.
+
+More details on running the tests can be found in the
+[development](docs/DEVELOPMENT.md) document.
+
 ## License
 
 This project is licensed under either of:

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,138 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use event_manager::utilities::subscribers::{
+    CounterInnerMutSubscriber, CounterSubscriber, CounterSubscriberWithData,
+};
+use event_manager::{EventManager, EventSubscriber, MutEventSubscriber, SubscriberOps};
+use std::sync::{Arc, Mutex};
+
+// Test the performance of event manager when it manages a single subscriber type.
+// The performance is assessed under stress, all added subscribers have active events.
+fn run_basic_subscriber(c: &mut Criterion) {
+    let no_of_subscribers = 200;
+
+    let mut event_manager = EventManager::<CounterSubscriber>::new().unwrap();
+    for _ in 0..no_of_subscribers {
+        let mut counter_subscriber = CounterSubscriber::new();
+        counter_subscriber.trigger_event();
+        event_manager.add_subscriber(counter_subscriber);
+    }
+
+    c.bench_function("process_basic", |b| {
+        b.iter(|| {
+            let ev_count = event_manager.run().unwrap();
+            assert_eq!(ev_count, no_of_subscribers)
+        })
+    });
+}
+
+// Test the performance of event manager when the subscribers are wrapped in an Arc<Mutex>.
+// The performance is assessed under stress, all added subscribers have active events.
+fn run_arc_mutex_subscriber(c: &mut Criterion) {
+    let no_of_subscribers = 200;
+
+    let mut event_manager = EventManager::<Arc<Mutex<CounterSubscriber>>>::new().unwrap();
+    for _ in 0..no_of_subscribers {
+        let counter_subscriber = Arc::new(Mutex::new(CounterSubscriber::new()));
+        counter_subscriber.lock().unwrap().trigger_event();
+        event_manager.add_subscriber(counter_subscriber);
+    }
+
+    c.bench_function("process_with_arc_mutex", |b| {
+        b.iter(|| {
+            let ev_count = event_manager.run().unwrap();
+            assert_eq!(ev_count, no_of_subscribers)
+        })
+    });
+}
+
+// Test the performance of event manager when the subscribers are wrapped in an Arc, and they
+// leverage inner mutability to update their internal state.
+// The performance is assessed under stress, all added subscribers have active events.
+fn run_subscriber_with_inner_mut(c: &mut Criterion) {
+    let no_of_subscribers = 200;
+
+    let mut event_manager = EventManager::<Arc<dyn EventSubscriber + Send + Sync>>::new().unwrap();
+    for _ in 0..no_of_subscribers {
+        let counter_subscriber = CounterInnerMutSubscriber::new();
+        counter_subscriber.trigger_event();
+        event_manager.add_subscriber(Arc::new(counter_subscriber));
+    }
+
+    c.bench_function("process_with_inner_mut", |b| {
+        b.iter(|| {
+            let ev_count = event_manager.run().unwrap();
+            assert_eq!(ev_count, no_of_subscribers)
+        })
+    });
+}
+
+// Test the performance of event manager when it manages subscribers of different types, that are
+// wrapped in an Arc<Mutex>. Also, make use of `Events` with custom user data
+// (using CounterSubscriberWithData).
+// The performance is assessed under stress, all added subscribers have active events, and the
+// CounterSubscriberWithData subscribers have multiple active events.
+fn run_multiple_subscriber_types(c: &mut Criterion) {
+    let no_of_subscribers = 100;
+
+    let mut event_manager = EventManager::<Arc<Mutex<dyn MutEventSubscriber>>>::new()
+        .expect("Cannot create event manager.");
+
+    for i in 0..no_of_subscribers {
+        // The `CounterSubscriberWithData` expects to receive a number as a parameter that
+        // represents the number it can use as its inner Events data.
+        let mut data_subscriber = CounterSubscriberWithData::new(i * no_of_subscribers);
+        data_subscriber.trigger_all_counters();
+        event_manager.add_subscriber(Arc::new(Mutex::new(data_subscriber)));
+
+        let mut counter_subscriber = CounterSubscriber::new();
+        counter_subscriber.trigger_event();
+        event_manager.add_subscriber(Arc::new(Mutex::new(counter_subscriber)));
+    }
+
+    c.bench_function("process_dynamic_dispatch", |b| {
+        b.iter(|| {
+            let _ = event_manager.run().unwrap();
+        })
+    });
+}
+
+// Test the performance of event manager when it manages a single subscriber type.
+// Just a few of the events are active in this test scenario.
+fn run_with_few_active_events(c: &mut Criterion) {
+    let no_of_subscribers = 200;
+
+    let mut event_manager = EventManager::<CounterSubscriber>::new().unwrap();
+
+    for i in 0..no_of_subscribers {
+        let mut counter_subscriber = CounterSubscriber::new();
+        // Let's activate the events for a few subscribers (i.e. only the ones that are
+        // divisible by 23). 23 is a random number that I just happen to like.
+        if i % 23 == 0 {
+            counter_subscriber.trigger_event();
+        }
+        event_manager.add_subscriber(counter_subscriber);
+    }
+
+    c.bench_function("process_dispatch_few_events", |b| {
+        b.iter(|| {
+            let _ = event_manager.run().unwrap();
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(200)
+        .measurement_time(std::time::Duration::from_secs(40));
+    targets = run_basic_subscriber, run_arc_mutex_subscriber, run_subscriber_with_inner_mut,
+              run_multiple_subscriber_types, run_with_few_active_events
+}
+
+criterion_main! {
+    benches
+}

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 93.5,
-  "exclude_path": "tests/",
-  "crate_features": "remote_endpoint"
+  "exclude_path": "tests/,benches/,utilities/",
+  "crate_features": "remote_endpoint,test_utilities"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.1,
+  "coverage_score": 84.9,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 86.1,
-  "exclude_path": "tests/",
-  "crate_features": "remote_endpoint"
+  "exclude_path": "tests/,benches/,utilities/",
+  "crate_features": "remote_endpoint,test_utilities"
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,32 @@
+# Development and Testing
+
+## Testing
+
+The `event-manager` is tested using:
+- unit tests - defined in their corresponding modules
+- Rust integration tests - defined in the [tests](../tests) directory
+- performance tests - defined in the [benches](../benches) directory
+
+The integration and performance tests share subscribers implementations
+which can be found under the [src/utilities](../src/utilities) module.
+
+The `utilities` module is compiled only when using the `test_utilities`
+feature. To run unit tests, integration tests, and performance tests, the user
+needs to specify the `test_utilities` feature; otherwise the build fails.
+
+```bash
+cargo test --features test_utilities
+cargo bench --features test_utilities
+```
+
+We recommend running all the tests before submitting a PR as follows:
+
+```bash
+cargo test --all-features
+```
+
+Performance tests are implemented using
+[criterion](https://docs.rs/crate/criterion/). Running the performance tests
+locally should work, but only when they're run as part of the CI performance
+improvements/degradations can be noticed. More details about performance tests
+[here](https://github.com/rust-vmm/rust-vmm-ci#performance-tests).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ mod epoll;
 mod events;
 mod manager;
 mod subscribers;
+#[doc(hidden)]
+#[cfg(feature = "test_utilities")]
+pub mod utilities;
 
 pub use events::{EventOps, Events};
 pub use manager::EventManager;

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,0 +1,18 @@
+// Helper module for tests utilities.
+//
+// This module is only compiled with `test_utilities` feature on purpose.
+// For production code, we do not want to export this functionality.
+// At the same time, we need the test utilities to be public such that they can
+// be used by multiple categories of tests. Two examples that deem this module
+// necessary are the benchmark tests and the integration tests where the implementations
+// of subscribers are shared.
+//
+// Having this module as a feature comes with a disadvantage that needs to be kept in mind.
+// `cargo test` will only work when ran with `--feature test-utilities` (or with --all-features). A
+// much nicer way to implement this would've been with a utilities crate that is used as
+// `dev-dependencies`. Unfortunately, this is not possible because it would introduce a cyclic
+// dependency. The `utilities` module has a dependency on `event-manager` because it needs to
+// implement the `EventSubscriber` traits, and `event-manager` has a dependency on utilities so
+// that they can be used in tests.
+#![doc(hidden)]
+pub mod subscribers;

--- a/src/utilities/subscribers.rs
+++ b/src/utilities/subscribers.rs
@@ -5,7 +5,6 @@
 // not all of them are used in all the separate integration test modules.
 // Cargo bug: https://github.com/rust-lang/rust/issues/46379
 // Let's allow dead code so that we don't get warnings all the time.
-#![allow(dead_code)]
 /// This module defines common subscribers that showcase the usage of the event-manager.
 ///
 /// 1. CounterSubscriber:
@@ -25,7 +24,7 @@
 ///     - the subscriber makes use of inner mutability; multi-threaded applications might want to
 ///       use inner mutability instead of having something heavy weight (i.e. Arc<Mutex>).
 ///     - this subscriber implement `EventSubscriber`.
-use event_manager::{EventOps, EventSubscriber, Events, MutEventSubscriber};
+use crate::{EventOps, EventSubscriber, Events, MutEventSubscriber};
 use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
 
 use std::fmt::{Display, Formatter, Result};

--- a/tests/basic_event_manager.rs
+++ b/tests/basic_event_manager.rs
@@ -6,14 +6,9 @@
 //
 // The application has an `EventManager` and can register multiple subscribers
 // of type `CounterSubscriber`.
-extern crate event_manager;
-extern crate vmm_sys_util;
-
-mod subscribers;
-
+use event_manager::utilities::subscribers::CounterSubscriber;
 use event_manager::{EventManager, SubscriberId, SubscriberOps};
 use std::ops::Drop;
-use subscribers::CounterSubscriber;
 
 struct App {
     event_manager: EventManager<CounterSubscriber>,

--- a/tests/multi_threaded.rs
+++ b/tests/multi_threaded.rs
@@ -1,11 +1,12 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
-mod subscribers;
 
+use event_manager::utilities::subscribers::{
+    CounterInnerMutSubscriber, CounterSubscriber, CounterSubscriberWithData,
+};
 use event_manager::{EventManager, EventSubscriber, MutEventSubscriber, SubscriberOps};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use subscribers::{CounterInnerMutSubscriber, CounterSubscriber, CounterSubscriberWithData};
 
 // Showcase how you can manage subscribers of different types using the same event manager
 // in a multithreaded context.


### PR DESCRIPTION
To de-duplicate the subscriber definition between integration tests and benchmark tests, I also added a utilities module that is only used in tests and it is gated by `test_utilities` features.

Fixes: #7 