### PR TITLE
Remove unreachable() when no fd is found

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.9,
+  "coverage_score": 86.2,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -160,8 +160,10 @@ impl<S: MutEventSubscriber> EventManager<S> {
                     }
                 }
 
-                // This should not occur during normal operation.
-                unreachable!("Received event on fd from subscriber that is not registered");
+                // We can actually reach this point during normal operation, because `fd`
+                // keys can be removed from the `subscribers` map by any subscriber via
+                // `EventOps::remove` during the invocation of its `process` callback.
+                // For now, we simply ignore the condition.
             }
         }
 


### PR DESCRIPTION
This PR fixes a potential crash which may occur during normal operation if a subscriber removes an `fd` via `EventOps::remove`, while an event associated with that `fd` is pending dispatch by the event manager.