### PR TITLE
Test improvements

### DIFF
--- a/.buildkite/custom-pipeline.yml
+++ b/.buildkite/custom-pipeline.yml
@@ -81,7 +81,7 @@ steps:
 
   - label: "performance-x86"
     commands:
-      - pytest rust-vmm-ci/integration_tests/test_benchmark.py
+      - pytest -s rust-vmm-ci/integration_tests/test_benchmark.py
     retry:
       automatic: false
     agents:
@@ -97,7 +97,7 @@ steps:
 
   - label: "performance-arm"
     commands:
-      - pytest rust-vmm-ci/integration_tests/test_benchmark.py
+      - pytest -s rust-vmm-ci/integration_tests/test_benchmark.py
     retry:
       automatic: false
     agents:

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.5,
+  "coverage_score": 86,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod subscribers;
 pub mod utilities;
 
 pub use events::{EventOps, Events};
-pub use manager::EventManager;
+pub use manager::{EventManager, MAX_READY_EVENTS_CAPACITY};
 
 #[cfg(feature = "remote_endpoint")]
 mod endpoint;
@@ -50,6 +50,8 @@ pub enum Error {
     FdAlreadyRegistered,
     /// The Subscriber ID does not exist or is no longer associated with a Subscriber.
     InvalidId,
+    /// The ready list capacity passed to `EventManager::new` is invalid.
+    InvalidCapacity,
 }
 
 impl std::fmt::Display for Error {
@@ -75,6 +77,7 @@ impl std::fmt::Display for Error {
                 "event_manager: file descriptor has already been registered"
             ),
             Error::InvalidId => write!(f, "event_manager: invalid subscriber Id"),
+            Error::InvalidCapacity => write!(f, "event_manager: invalid ready_list capacity"),
         }
     }
 }
@@ -91,6 +94,7 @@ impl std::error::Error for Error {
             Error::Epoll(e) => Some(e),
             Error::FdAlreadyRegistered => None,
             Error::InvalidId => None,
+            Error::InvalidCapacity => None,
         }
     }
 }

--- a/tests/negative_tests.rs
+++ b/tests/negative_tests.rs
@@ -1,0 +1,88 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::os::unix::{io::AsRawFd, net::UnixStream};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use event_manager::{EventManager, EventOps, EventSubscriber, Events, SubscriberOps};
+use vmm_sys_util::epoll::EventSet;
+
+#[derive(Debug)]
+struct UnixStreamSubscriber {
+    stream: UnixStream,
+    rhup_count: AtomicU64,
+    // When this flag is used, in the process function the subscriber will
+    // unregister the fd where an error was received.
+    // The errors that need to be handled: `EventSet::HANG_UP`, `EventSet::ERROR`.
+    with_unregister_on_err: bool,
+}
+
+impl UnixStreamSubscriber {
+    fn new(stream: UnixStream) -> UnixStreamSubscriber {
+        Self {
+            stream,
+            rhup_count: AtomicU64::new(0),
+            with_unregister_on_err: false,
+        }
+    }
+
+    fn new_with_unregister_on_err(stream: UnixStream) -> UnixStreamSubscriber {
+        Self {
+            stream,
+            rhup_count: AtomicU64::new(0),
+            with_unregister_on_err: true,
+        }
+    }
+}
+
+impl EventSubscriber for UnixStreamSubscriber {
+    fn process(&self, events: Events, ops: &mut EventOps<'_>) {
+        if events.event_set().contains(EventSet::HANG_UP) {
+            let _ = self.rhup_count.fetch_add(1, Ordering::Relaxed);
+            if self.with_unregister_on_err {
+                ops.remove(Events::empty(&self.stream)).unwrap();
+            }
+        }
+    }
+
+    fn init(&self, ops: &mut EventOps<'_>) {
+        ops.add(Events::new(&self.stream, EventSet::IN)).unwrap();
+    }
+}
+
+#[test]
+fn test_handling_errors_in_subscriber() {
+    let (sock1, sock2) = UnixStream::pair().unwrap();
+
+    let mut event_manager = EventManager::<Arc<dyn EventSubscriber>>::new().unwrap();
+    let subscriber = Arc::new(UnixStreamSubscriber::new(sock1));
+    event_manager.add_subscriber(subscriber.clone());
+
+    unsafe { libc::close(sock2.as_raw_fd()) };
+
+    event_manager.run_with_timeout(100).unwrap();
+    event_manager.run_with_timeout(100).unwrap();
+    event_manager.run_with_timeout(100).unwrap();
+
+    // Since the subscriber did not remove the event from its watch list, the
+    // `EPOLLRHUP` error will continuously be a ready event each time `run` is called.
+    // We called `run_with_timeout` 3 times, hence we expect `rhup_count` to be 3.
+    assert_eq!(subscriber.rhup_count.load(Ordering::Relaxed), 3);
+
+    let (sock1, sock2) = UnixStream::pair().unwrap();
+    let subscriber_with_unregister =
+        Arc::new(UnixStreamSubscriber::new_with_unregister_on_err(sock1));
+    event_manager.add_subscriber(subscriber_with_unregister.clone());
+
+    unsafe { libc::close(sock2.as_raw_fd()) };
+
+    let ready_list_len = event_manager.run_with_timeout(100).unwrap();
+    assert_eq!(ready_list_len, 2);
+    // At this point the `subscriber_with_unregister` should not yield events anymore.
+    // We expect the number of ready fds to be 1.
+    let ready_list_len = event_manager.run_with_timeout(100).unwrap();
+    assert_eq!(ready_list_len, 1);
+}

--- a/tests/negative_tests.rs
+++ b/tests/negative_tests.rs
@@ -7,7 +7,9 @@ use std::sync::{
     Arc,
 };
 
-use event_manager::{EventManager, EventOps, EventSubscriber, Events, SubscriberOps};
+use event_manager::{
+    EventManager, EventOps, EventSubscriber, Events, SubscriberOps, MAX_READY_EVENTS_CAPACITY,
+};
 use vmm_sys_util::epoll::EventSet;
 
 #[derive(Debug)]
@@ -85,4 +87,17 @@ fn test_handling_errors_in_subscriber() {
     // We expect the number of ready fds to be 1.
     let ready_list_len = event_manager.run_with_timeout(100).unwrap();
     assert_eq!(ready_list_len, 1);
+}
+
+#[test]
+fn test_max_ready_list_size() {
+    assert!(
+        EventManager::<Arc<dyn EventSubscriber>>::new_with_capacity(MAX_READY_EVENTS_CAPACITY)
+            .is_ok()
+    );
+    assert!(EventManager::<Arc<dyn EventSubscriber>>::new_with_capacity(
+        MAX_READY_EVENTS_CAPACITY + 1
+    )
+    .is_err());
+    assert!(EventManager::<Arc<dyn EventSubscriber>>::new_with_capacity(usize::MAX).is_err())
 }


### PR DESCRIPTION
- added negative tests
- run the performance test with `-s` so we can see the output