### PR TITLE
Implements iterrator to walk all pending IO events

### DIFF
--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -2,11 +2,53 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 use std::os::unix::io::RawFd;
 
 use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent};
 
 use super::{Errno, Error, EventOps, Result, SubscriberId};
+
+/// Collection of events corresponding to the `epoll` ready list.
+pub(crate) struct ReadyEvents(Vec<EpollEvent>);
+impl ReadyEvents {
+    /// Creates a new `ReadyEvents` with `capacity`.
+    fn new(capacity: usize) -> Self {
+        ReadyEvents(vec![EpollEvent::default(); capacity])
+    }
+
+    /// Remove the `EpollEvent` that corresponds to `fd`.
+    fn remove(&mut self, fd: RawFd) {
+        for event in self.0.iter_mut() {
+            if event.fd() == fd {
+                *event = EpollEvent::default();
+            }
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a ReadyEvents {
+    type Item = EpollEvent;
+    type IntoIter = std::vec::IntoIter<EpollEvent>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.clone().into_iter()
+    }
+}
+
+impl Deref for ReadyEvents {
+    type Target = Vec<EpollEvent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ReadyEvents {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 // Internal use structure that keeps the epoll related state of an EventManager.
 pub(crate) struct EpollWrapper {
@@ -19,7 +61,7 @@ pub(crate) struct EpollWrapper {
     // This is used to keep track of all fds associated with a subscriber.
     pub(crate) subscriber_watch_list: HashMap<SubscriberId, Vec<RawFd>>,
     // A scratch buffer to avoid allocating/freeing memory on each poll iteration.
-    pub(crate) ready_events: Vec<EpollEvent>,
+    pub(crate) ready_events: ReadyEvents,
 }
 
 impl EpollWrapper {
@@ -28,16 +70,16 @@ impl EpollWrapper {
             epoll: Epoll::new().map_err(|e| Error::Epoll(Errno::from(e)))?,
             fd_dispatch: HashMap::new(),
             subscriber_watch_list: HashMap::new(),
-            ready_events: vec![EpollEvent::default(); ready_events_capacity],
+            ready_events: ReadyEvents::new(ready_events_capacity),
         })
     }
 
     // Poll the underlying epoll fd for pending IO events.
     pub(crate) fn poll(&mut self, milliseconds: i32) -> Result<usize> {
         let event_count = match self.epoll.wait(
-            self.ready_events.capacity(),
+            self.ready_events.0.capacity(),
             milliseconds,
-            &mut self.ready_events[..],
+            &mut self.ready_events.0[..],
         ) {
             Ok(ev) => ev,
             // EINTR is not actually an error that needs to be handled. The documentation
@@ -63,20 +105,14 @@ impl EpollWrapper {
             let _ = self
                 .epoll
                 .ctl(ControlOperation::Delete, fd, EpollEvent::default());
-            self.remove_event(fd);
+            self.remove_fd(fd);
         }
     }
 
-    // Flush and stop receiving IO events associated with the file descriptor.
-    pub(crate) fn remove_event(&mut self, fd: RawFd) {
+    // Remove the file descriptor from the dispatch table and pending fd set.
+    pub(crate) fn remove_fd(&mut self, fd: RawFd) {
         self.fd_dispatch.remove(&fd);
-        for event in self.ready_events.iter_mut() {
-            if event.fd() == fd {
-                // It's a little complex to remove the entry from the Vec, so do soft removal
-                // by setting it to default value.
-                *event = EpollEvent::default();
-            }
-        }
+        self.ready_events.remove(fd);
     }
 
     // Gets the id of the subscriber associated with the provided fd (if such an association

--- a/src/events.rs
+++ b/src/events.rs
@@ -256,7 +256,7 @@ impl<'a> EventOps<'a> {
     pub fn remove(&mut self, events: Events) -> Result<()> {
         // TODO: Add some more checks here?
         self.ctl(ControlOperation::Delete, events)?;
-        self.epoll_wrapper.remove_event(events.fd());
+        self.epoll_wrapper.remove_fd(events.fd());
 
         if let Some(watch_list) = self
             .epoll_wrapper

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -145,8 +145,8 @@ impl<S: MutEventSubscriber> EventManager<S> {
 
         // TODO: implement an iterator for EpollWrapper to simplify the abstraction
         // https://github.com/rust-vmm/event-manager/issues/44
-        for ev_index in 0..event_count {
-            let event = self.epoll_context.ready_events[ev_index];
+        for event in &self.epoll_context.ready_events {
+            // let a = self.epoll_context.ready_events;
             let fd = event.fd();
 
             // Check whether this event has been discarded.


### PR DESCRIPTION
Changes in this cr combine changes from https://github.com/rust-vmm/event-manager/pull/45
which implement a separate abstraction for ready_list called ReadyEvents, creating
a new wrapper struct around a Vec<EpollEvent> instead of using a vector directly.
Using the new ReadyEvents abstraction we implement an iterator to walk the pending
IO events that are put inside the vector wrapped by ReadyEvents.