### PR TITLE
release v0.2.1 and update vmm-sys-util dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.2.1
+
+## Changed
+
+- Updated the vmm-sys-util dependency to v0.8.0.
+
+## Fixed
+
+- Fixed `RemoteEndpoint` `Clone` implementation.
+- Check the maximum capacity when calling `EventManager::new`.
+
 # v0.2.0
 
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event-manager"
-version = "0.2.0"
+version = "0.2.1"
 description = "Abstractions for implementing event based systems"
 keywords = ["events"]
 repository = "https://github.com/rust-vmm/event-manager"
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-vmm-sys-util = ">=0.6.0"
+vmm-sys-util = ">=0.8.0"
 libc = ">=0.2.39"
 
 [dev-dependencies]

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86,
+  "coverage_score": 85.9,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -34,11 +34,7 @@ impl EpollWrapper {
 
     // Poll the underlying epoll fd for pending IO events.
     pub(crate) fn poll(&mut self, milliseconds: i32) -> Result<usize> {
-        let event_count = match self.epoll.wait(
-            self.ready_events.capacity(),
-            milliseconds,
-            &mut self.ready_events[..],
-        ) {
+        let event_count = match self.epoll.wait(milliseconds, &mut self.ready_events[..]) {
             Ok(ev) => ev,
             // EINTR is not actually an error that needs to be handled. The documentation
             // for epoll.run specifies that run exits when it for an event, on timeout, or


### PR DESCRIPTION
The epoll interface changed, so updates were needed to call wait.
This release is needed so we can update the dependencies in vmm-reference as well.