### PR TITLE
Don't hide underlying errors

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 93.5,
+  "coverage_score": 93.2,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.9,
+  "coverage_score": 85.6,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,16 @@ impl std::fmt::Display for Error {
                 "event_manager: failed to receive message from remote endpoint"
             ),
             #[cfg(feature = "remote_endpoint")]
-            Error::EventFd(_e) => {
-                write!(f, "event_manager: failed to manage EventFd file descriptor")
-            }
-            Error::Epoll(_e) => write!(f, "event_manager: failed to manage epoll file descriptor"),
+            Error::EventFd(e) => write!(
+                f,
+                "event_manager: failed to manage EventFd file descriptor: {}",
+                e
+            ),
+            Error::Epoll(e) => write!(
+                f,
+                "event_manager: failed to manage epoll file descriptor: {}",
+                e
+            ),
             Error::FdAlreadyRegistered => write!(
                 f,
                 "event_manager: file descriptor has already been registered"


### PR DESCRIPTION
fmt() shouldn't hide underlying errors. For example, epoll_create(2)
would return EINVAL, EMFILE or ENOMEM. Having the specific error code
would help troubleshooting.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>