### PR TITLE
Update rust-vmm-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.6,
+  "coverage_score": 87.0,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,11 +249,15 @@ impl<T: MutEventSubscriber + ?Sized> EventSubscriber for Mutex<T> {
 
 impl<T: MutEventSubscriber + ?Sized> MutEventSubscriber for Mutex<T> {
     fn process(&mut self, events: Events, ops: &mut EventOps) {
-        self.lock().unwrap().process(events, ops);
+        // If another user of this mutex panicked while holding the mutex, then
+        // we terminate the process.
+        self.get_mut().unwrap().process(events, ops);
     }
 
     fn init(&mut self, ops: &mut EventOps) {
-        self.lock().unwrap().init(ops);
+        // If another user of this mutex panicked while holding the mutex, then
+        // we terminate the process.
+        self.get_mut().unwrap().init(ops);
     }
 }
 


### PR DESCRIPTION
This update brings the latest Rust version (1.52.1), and some fixes are needed (coverage & clippy).
Also noticed that there is not .gitignore committed to the repo, so I added one.