### PR TITLE
upgrade criterion

### DIFF
--- a/.buildkite/custom-pipeline.yml
+++ b/.buildkite/custom-pipeline.yml
@@ -8,8 +8,8 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
+      - docker#v3.8.0:
+          image: "rustvmm/dev:v12"
           always-pull: true
 
   - label: "build-musl-x86-remote_endpoint"
@@ -21,8 +21,8 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
+      - docker#v3.8.0:
+          image: "rustvmm/dev:v12"
           always-pull: true
 
   - label: "build-gnu-arm-remote_endpoint"
@@ -34,8 +34,8 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
+      - docker#v3.8.0:
+          image: "rustvmm/dev:v12"
           always-pull: true
 
   - label: "build-musl-arm-remote_endpoint"
@@ -47,8 +47,8 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
+      - docker#v3.8.0:
+          image: "rustvmm/dev:v12"
           always-pull: true
 
   - label: "check-warnings-x86"
@@ -60,9 +60,9 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
-          image: "rustvmm/dev:v6"
+          image: "rustvmm/dev:v12"
           always-pull: true
 
   - label: "check-warnings-arm"
@@ -74,9 +74,9 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
+      - docker#v3.8.0:
           privileged: true
-          image: "rustvmm/dev:v6"
+          image: "rustvmm/dev:v12"
           always-pull: true
 
   - label: "performance-x86"
@@ -88,8 +88,8 @@ steps:
       platform: x86_64.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
+      - docker#v3.8.0:
+          image: "rustvmm/dev:v12"
           environment:
             - "PYTHONIOENCODING=utf-8"
           always-pull: true
@@ -104,8 +104,8 @@ steps:
       platform: arm.metal
       os: linux
     plugins:
-      - docker#v3.0.1:
-          image: "rustvmm/dev:v6"
+      - docker#v3.8.0:
+          image: "rustvmm/dev:v12"
           environment:
             - "PYTHONIOENCODING=utf-8"
           always-pull: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ vmm-sys-util = ">=0.8.0"
 libc = ">=0.2.39"
 
 [dev-dependencies]
-# Locking this version to 0.3.0 so that we can compare benchmark results with critcmp.
-criterion = "=0.3.0"
+criterion = "0.3.5"
 
 [features]
 remote_endpoint = []


### PR DESCRIPTION
This is needed so we can run with critcmp.

The criterion is no longer forced on a specific version so that we can upgrade both criterion & critcmp without needing explicit PRs. If it comes to an incompatibility between the critcmp version in the container, and the criterion version, then we can always just fix the dependency to the latest known to work (which is now defined in Cargo.toml).