### PR TITLE
renamed dependabot.yaml to .yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-
-    


### PR DESCRIPTION
And removed whitespaces.

Signed-off-by: Andreea Florescu <fandree@amazon.com>