### PR TITLE
Small grammar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ mechanism for handling I/O notifications.
 
 ## Design
 
-This crate is build around two abstractions:
+This crate is built around two abstractions:
 - Event Manager
 - Event Subscriber
 


### PR DESCRIPTION
Change "build around" to "built around"

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>