### PR TITLE
Build docs.rs documentation with `remote_endpoint` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming version
+
+## Changed
+
+- Added `remote_endpoint` feature to generated docs.rs documentation.
+
 # v0.3.0
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ libc = "0.2.39"
 [dev-dependencies]
 criterion = "0.3.5"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 remote_endpoint = []
 test_utilities = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Event Manager traits and implementation.
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};


### PR DESCRIPTION
### Summary of the PR

The current documentation build in docs.rs does not include the `remote_endpoint` feature, which might lead so users of the crate not being aware of its existence.

For more information on the table introduced in Cargo.toml see: https://docs.rs/about/metadata

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `(N/A)` All added/changed functionality has a corresponding unit/integration
  test.
- `(N/A)` Any newly added `unsafe` code is properly documented.
