### PR TITLE
Derive `Debug` for multiple types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changed
 
 - Added `remote_endpoint` feature to generated docs.rs documentation.
+- Derived the `Debug` trait for multiple types
 
 # v0.3.0
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.6,
+  "coverage_score": 83.90,
   "exclude_path": "tests/,benches/,utilities/",
   "crate_features": "remote_endpoint,test_utilities"
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -48,6 +48,7 @@ pub(crate) struct FnMsg<S> {
 }
 
 // Used by the `EventManager` to keep state associated with the channel.
+#[derive(Debug)]
 pub(crate) struct EventManagerChannel<S> {
     // A clone of this is given to every `RemoteEndpoint` and used to signal the presence of
     // an new message on the channel.
@@ -84,6 +85,7 @@ impl<S> EventManagerChannel<S> {
 }
 
 /// Enables interactions with an `EventManager` that runs on a different thread of execution.
+#[derive(Debug)]
 pub struct RemoteEndpoint<S> {
     // A sender associated with `EventManager` channel requests are sent over.
     msg_sender: Sender<FnMsg<S>>,

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -9,6 +9,7 @@ use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent};
 use super::{Errno, Error, EventOps, Result, SubscriberId};
 
 // Internal use structure that keeps the epoll related state of an EventManager.
+#[derive(Debug)]
 pub(crate) struct EpollWrapper {
     // The epoll wrapper.
     pub(crate) epoll: Epoll,

--- a/src/events.rs
+++ b/src/events.rs
@@ -202,6 +202,7 @@ impl Events {
 /// removal of events in the watchlist.
 // Right now this is a concrete object, but going further it can be turned into a trait and
 // passed around as a trait object.
+#[derive(Debug)]
 pub struct EventOps<'a> {
     // Mutable reference to the EpollContext of an EventManager.
     epoll_wrapper: &'a mut EpollWrapper,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 //! Event Manager traits and implementation.
+#![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -16,6 +16,7 @@ use super::Errno;
 use super::{Error, EventOps, Events, MutEventSubscriber, Result, SubscriberId, SubscriberOps};
 
 /// Allows event subscribers to be registered, connected to the event loop, and later removed.
+#[derive(Debug)]
 pub struct EventManager<T> {
     subscribers: Subscribers<T>,
     epoll_context: EpollWrapper,

--- a/src/subscribers.rs
+++ b/src/subscribers.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 // Internal structure used to keep the set of subscribers registered with an EventManger.
 // This structure is a thin wrapper over a `HashMap` in which the keys are uniquely
 // generated when calling `add`.
+#[derive(Debug)]
 pub(crate) struct Subscribers<T> {
     // The key is the unique id of the subscriber and the entry is the `Subscriber`.
     subscribers: HashMap<SubscriberId, T>,

--- a/src/utilities/subscribers.rs
+++ b/src/utilities/subscribers.rs
@@ -36,6 +36,7 @@ use crate::{EventOps, EventSubscriber, Events, MutEventSubscriber};
 /// A `Counter` is a helper structure for creating subscribers that increment a value
 /// each time an event is triggered.
 /// The `Counter` allows users to assert and de-assert an event, and to query the counter value.
+#[derive(Debug)]
 pub struct Counter {
     event_fd: EventFd,
     counter: u64,
@@ -81,6 +82,7 @@ impl Default for Counter {
 
 // A dummy subscriber that increments a counter whenever it processes
 // a new request.
+#[derive(Debug)]
 pub struct CounterSubscriber(Counter);
 
 impl std::ops::Deref for CounterSubscriber {
@@ -137,6 +139,7 @@ impl MutEventSubscriber for CounterSubscriber {
 // registering & processing events.
 // Using 3 counters each having associated event data to showcase the implementation of
 // EventSubscriber trait with this scenario.
+#[derive(Debug)]
 pub struct CounterSubscriberWithData {
     counter_1: Counter,
     counter_2: Counter,
@@ -275,6 +278,7 @@ impl MutEventSubscriber for CounterSubscriberWithData {
     }
 }
 
+#[derive(Debug)]
 pub struct CounterInnerMutSubscriber {
     event_fd: EventFd,
     counter: AtomicU64,


### PR DESCRIPTION
### Summary of the PR

Add free `Debug` derives to multiple types, and add the [`#![deny(missing_debug_implementations)]`](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.MISSING_DEBUG_IMPLEMENTATIONS.html) attribute to prevent similar issues in the future.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `N/A` All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `N/A` Any newly added `unsafe` code is properly documented.
